### PR TITLE
Small housekeeping tasks, Dense adjoint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.5.1
+  rev: v0.9.4
   hooks:
     # Run the linter.
     - id: ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,9 @@ markers = [
     "plot: tests that involve plotting",
 ]
 
+[tool.coverage.run]
+omit = ["*/tests/*"] # Both test/ and tests/
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/src/torchlinops/functional/_unfold/fold.py
+++ b/src/torchlinops/functional/_unfold/fold.py
@@ -26,7 +26,19 @@ def fold(
     stride: tuple,
     mask: Optional[Bool[Tensor, "..."]] = None,
 ) -> Tensor:
-    """Cube-like unfolding"""
+    """Accumulate an array of blocks into a full array
+
+    Parameters
+    ----------
+    x : Tensor
+        Shape [B..., blocks, block_size]
+
+    Returns
+    -------
+    Tensor: Shape [B..., *im_size]
+        If mask is not None, block_size will be an int equal to the number of True elements in the mask
+        Otherwise it will be the full block shape.
+    """
     if mask is not None:
         nblocks = get_nblocks(im_size, block_size, stride)
         if len(x.shape) > len(nblocks) + 1:

--- a/src/torchlinops/functional/_unfold/unfold.py
+++ b/src/torchlinops/functional/_unfold/unfold.py
@@ -20,13 +20,26 @@ MAX_TENSOR_POW_OF_2 = 20
 
 
 def unfold(
-    x,
+    x: Shaped[Tensor, "..."],
     block_size: tuple,
     stride: Optional[tuple] = None,
     mask: Optional[Bool[Tensor, "..."]] = None,
 ) -> Tensor:
     """Wrapper that dispatches complex and real tensors
     Also precomputes some shapes
+
+    Parameters
+    ----------
+    x : Tensor
+        Shape [B..., *im_size]
+
+    Returns
+    -------
+    Tensor: Shape [B..., *blocks, *block_size]
+        If mask is not None, block_size will be an int equal to the number of True elements in the mask
+        Otherwise it will be the full block shape.
+
+
     """
     x_flat, shapes = prep_unfold_shapes(x, block_size, stride, mask)
     if torch.is_complex(x_flat):

--- a/src/torchlinops/linops/concat.py
+++ b/src/torchlinops/linops/concat.py
@@ -18,7 +18,7 @@ __all__ = ["Concat"]
 
 
 class Concat(NamedLinop):
-    """Concatenate some linops along a new dimension
+    """Concatenate some linops along an existing dimension
 
     Linops need not output tensors of the same size, but they should
     output tensors of the same number of dimensions

--- a/src/torchlinops/linops/dense.py
+++ b/src/torchlinops/linops/dense.py
@@ -82,20 +82,16 @@ class Dense(NamedLinop):
 
     @staticmethod
     def adj_fn(linop, x, /, weight):
-        return einsum(x, weight, linop.adj_einstr)
+        return einsum(x, weight.conj(), linop.adj_einstr)
 
     @staticmethod
     def normal_fn(linop, x, /, weight):
         return linop.adj_fn(linop.fn(x, weight), weight)
 
     def adjoint(self):
-        adj = type(self)(
-            self.weight.conj(),
-            self.weightshape,
-            self._shape.H.ishape,
-            self._shape.H.oshape,
-            self.broadcast_dims,
-        )
+        adj = copy(self)
+        adj.weight = nn.Parameter(self.weight.conj())
+        adj._shape = adj._shape.H
         return adj
 
     def normal(self, inner=None):

--- a/src/torchlinops/linops/dense.py
+++ b/src/torchlinops/linops/dense.py
@@ -92,6 +92,7 @@ class Dense(NamedLinop):
         adj = copy(self)
         adj.weight = nn.Parameter(self.weight.conj())
         adj._shape = adj._shape.H
+        adj._update_suffix(adjoint=self._name is not None)
         return adj
 
     def normal(self, inner=None):

--- a/src/torchlinops/linops/nameddim/_nameddim.py
+++ b/src/torchlinops/linops/nameddim/_nameddim.py
@@ -2,13 +2,7 @@ from copy import copy
 from dataclasses import dataclass
 from typing import Any, Tuple, List
 
-__all__ = [
-    "ND",
-    "NamedDimension",
-    "ELLIPSES",
-    "ANY",
-    "parse_dim_str",
-]
+__all__ = ["ND", "NamedDimension", "ELLIPSES", "ANY", "Dim", "parse_dim_str"]
 
 # Special dim names
 ELLIPSES = "..."
@@ -45,6 +39,9 @@ def parse_dim_str(s: str) -> tuple[str]:
             current += char
     parts.append(current)
     return tuple(parts)
+
+
+Dim = parse_dim_str
 
 
 @dataclass(slots=True, frozen=True)

--- a/src/torchlinops/linops/nameddim/_nameddim.py
+++ b/src/torchlinops/linops/nameddim/_nameddim.py
@@ -7,11 +7,44 @@ __all__ = [
     "NamedDimension",
     "ELLIPSES",
     "ANY",
+    "parse_dim_str",
 ]
 
 # Special dim names
 ELLIPSES = "..."
 ANY = "()"
+
+
+# Convenience function
+def parse_dim_str(s: str) -> tuple[str]:
+    """
+    Rules:
+    - dim begins with an uppercase letter
+    - dim cannot start with a number
+
+    Examples
+    --------
+    >>> parse_dim_str("ABCD")
+    ('A', 'B', 'C', 'D')
+    >>> parse_dim_str("NxNyNz")
+    ('Nx', 'Ny', 'Nz')
+    >>> parse_dim_str("A1B2Kx1Ky2")
+    ('A1', 'B2', 'Kx1', 'Ky2')
+    """
+    if len(s) == 0:
+        return tuple()
+    parts = []
+    current = s[0]
+    for char in s[1:]:
+        if char.isupper():
+            if char.isdigit():
+                raise ValueError(f"Dim cannot start with a digit in dim string {s}")
+            parts.append(current)
+            current = char
+        else:
+            current += char
+    parts.append(current)
+    return tuple(parts)
 
 
 @dataclass(slots=True, frozen=True)

--- a/src/torchlinops/linops/nufft.py
+++ b/src/torchlinops/linops/nufft.py
@@ -162,6 +162,11 @@ class NUFFT(Chain):
     def beta(width, oversamp):
         """
         https://sigpy.readthedocs.io/en/latest/_modules/sigpy/fourier.html#nufft
+
+        References
+        ----------
+        Beatty PJ, Nishimura DG, Pauly JM. Rapid gridding reconstruction with a minimal oversampling ratio.
+        IEEE Trans Med Imaging. 2005 Jun;24(6):799-808. doi: 10.1109/TMI.2005.848376. PMID: 15959939.
         """
         return torch.pi * (((width / oversamp) * (oversamp - 0.5)) ** 2 - 0.8) ** 0.5
 

--- a/src/torchlinops/linops/pad_last.py
+++ b/src/torchlinops/linops/pad_last.py
@@ -27,9 +27,9 @@ class PadLast(NamedLinop):
         out_shape: Optional[Shape] = None,
         batch_shape: Optional[Shape] = None,
     ):
-        assert (
-            len(pad_im_size) == len(im_size)
-        ), f"Padded and unpadded dims should be the same length. padded: {pad_im_size} unpadded: {im_size}"
+        assert len(pad_im_size) == len(im_size), (
+            f"Padded and unpadded dims should be the same length. padded: {pad_im_size} unpadded: {im_size}"
+        )
 
         if in_shape is None:
             self.in_im_shape = ND.infer(get_nd_shape(im_size))
@@ -132,7 +132,7 @@ def pad_to_size(grid_size, padded_size):
     even image + odd pad -> [pad // 2, pad // 2 + 1]
     odd image + odd pad -> [pad // 2 + 1, pad // 2]
 
-    Preserves the "center" of the image
+    Preserves the "center" of the image or kspace if it has been fftshifted
 
     Useful for e.g. padding an image to increase resolution in fourier domain
     """

--- a/src/torchlinops/linops/sampling.py
+++ b/src/torchlinops/linops/sampling.py
@@ -32,6 +32,7 @@ class Sampling(NamedLinop):
         idx : tuple of [M...] tensors
             One index for each "sampled" axis of the input tensor
             Use `canonicalize_idx` to turn a tensor of shape [M... D] to a D-tuple of index tensors.
+            idx is in range [0, size-1]
 
 
         """

--- a/src/torchlinops/linops/sampling.py
+++ b/src/torchlinops/linops/sampling.py
@@ -58,9 +58,9 @@ class Sampling(NamedLinop):
         return cls(idx, *args, **kwargs)
 
     @classmethod
-    def from_stacked_idx(cls, idx: Tensor, *args, **kwargs):
+    def from_stacked_idx(cls, idx: Tensor, *args, dim=-1, **kwargs):
         """Alternative constructor for index in [M... D] form"""
-        idx = F.canonicalize_idx(idx)
+        idx = F.canonicalize_idx(idx, dim=-1)
         return cls(idx, *args, **kwargs)
 
     def forward(self, x):


### PR DESCRIPTION
This pull request includes several updates and improvements across multiple files in the codebase. The changes focus on updating dependencies, enhancing documentation, adding new functionality, and refactoring existing code for better readability and performance.

### Dependency Updates:
* [`.pre-commit-config.yaml`](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L4-R4): Updated `ruff-pre-commit` version from `v0.5.1` to `v0.9.4`.

### Documentation Enhancements:
* [`src/torchlinops/functional/_unfold/fold.py`](diffhunk://#diff-e5f652c988095a171cc6ddfe791c66e1abc917725daad7fb7a3da1316b4ad62dL29-R41): Expanded the docstring for the `fold` function to include detailed parameter and return descriptions.
* [`src/torchlinops/functional/_unfold/unfold.py`](diffhunk://#diff-600a90e3a53fd06287c4eb213699c735e158aa53bb63b4ad4e7c48b8d9badbbdL23-R42): Added detailed docstring for the `unfold` function, describing parameters and return values.

### New Functionality:
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R91-R93): Added coverage configuration to omit test files from coverage reports.
* [`src/torchlinops/linops/nufft.py`](diffhunk://#diff-ceda08d3516aac65de0d275621615b0f5f995c2b7bad04a94bedb930b9dc7b41R41-R47): Introduced a new `mode` parameter in the `NUFFT` class to switch between "interpolate" and "sampling" modes. [[1]](diffhunk://#diff-ceda08d3516aac65de0d275621615b0f5f995c2b7bad04a94bedb930b9dc7b41R41-R47) [[2]](diffhunk://#diff-ceda08d3516aac65de0d275621615b0f5f995c2b7bad04a94bedb930b9dc7b41R88-R111)

### Refactoring:
* [`src/torchlinops/linops/concat.py`](diffhunk://#diff-7e3a528f0a0d827d9355322f92f7a42419b34662ceff2a51ab02bab860635522L21-R21): Updated the docstring to reflect that linops are concatenated along an existing dimension instead of a new one.
* [`src/torchlinops/linops/dense.py`](diffhunk://#diff-b36280ef7f689dba8d4bf422092e8ee5f05cfd52b33015e518b0033f01d3bc5fL85-R95): Refactored the `adjoint` method to use `copy` and updated the `adj_fn` method to use the conjugate of the weight.

### Codebase Simplification:
* [`src/torchlinops/linops/nameddim/_nameddim.py`](diffhunk://#diff-5e11a205dda78e00b710c1850bc7983f80a842cab16f665749cfd88f76d1d068L5-R46): Added a convenience function `parse_dim_str` and included it in `__all__`.

These changes collectively aim to improve the maintainability, readability, and functionality of the codebase.