### PR TITLE
0.3.17

### DIFF
--- a/src/torchlinops/functional/_interp/_circ_pad.py
+++ b/src/torchlinops/functional/_interp/_circ_pad.py
@@ -1,0 +1,113 @@
+from torch import Tensor
+
+from functools import partial
+import torch
+
+from einops import rearrange
+import torch.nn.functional as F
+from torch.autograd.functional import vjp
+
+
+def circular_pad(t: Tensor, padding: int | tuple):
+    # Infer dimension
+    if isinstance(padding, int):
+        ndim = t.ndim
+    else:  # isinstance(padding, tuple):
+        if len(padding) % 2:
+            raise ValueError(
+                f"Padding must have even length but got {len(padding)}: {padding}"
+            )
+        ndim = len(padding) // 2
+
+    # Flatten batch dim
+    batch_shape = t.shape[:-ndim]
+    if ndim < len(t.shape):
+        t = t.flatten(0, len(t.shape) - ndim - 1)
+    else:
+        # Add fake batch dim
+        t = t[None]
+
+    # Flag for cycling the batch one more time at the end
+    # Avoid uselessly cycling the batch if the initial ndim is <= 3
+    cycle_batch = False
+    while True:
+        pad_dims = min(ndim, 3)
+        pad = padding[: 2 * pad_dims]
+        t = circular_pad_nd(t, pad, pad_dims)
+
+        # Update
+        ndim -= pad_dims
+        if ndim == 0 and not cycle_batch:
+            break
+
+        padding = padding[2 * pad_dims :]
+
+        # Cycle remaining dims to the back, padded dims to the front
+        if pad_dims == 1:
+            t = rearrange(t, "... x -> x ...")
+        elif pad_dims == 2:
+            t = rearrange(t, "... x y  -> x y ...")
+        elif pad_dims == 3:
+            t = rearrange(t, "... x y z -> x y z ...")
+        cycle_batch = True
+        if ndim == 0:
+            break
+
+    if cycle_batch:
+        # Move batch dim back to front and unflatten
+        # Batch dim should be the only one left
+        t = rearrange(t, "... b -> b ...")
+    t = t.reshape(*batch_shape, *t.shape[1:])
+    return t
+
+
+def circular_pad_nd(t: Tensor, padding: int | tuple, ndim: int):
+    """
+    Parameters
+    ----------
+    t : Tensor
+        The tensor to be padded
+    padding : int or tuple
+        Follows same conventions as torch.nn.functional.pad
+    """
+
+    # Prep
+    oshape = list(t.shape)
+    for i, (padleft, padright) in enumerate(zip(padding[::2], padding[1::2])):
+        oshape[-(i + 1)] += padleft + padright
+
+    if ndim == 1:
+        t = rearrange(t, "... x -> (...) x")
+    elif ndim == 2:
+        t = rearrange(t, "... x y -> (...) x y")
+    elif ndim == 3:
+        t = rearrange(t, "... x y z -> (...) x y z ")
+    elif ndim > 3:
+        raise NotImplementedError(
+            "Circular padding not yet implemented for >3 dimensions"
+        )
+    else:
+        raise ValueError(f"ndim must be positive int but got {ndim}")
+
+    # Do pad
+    t = F.pad(t, padding, mode="circular")
+
+    # Postproc
+    t = t.reshape(*oshape)
+    return t
+
+
+def circular_pad_adjoint(t: Tensor, padding: int | tuple):
+    """Adjoint of circular pad
+    Uses vjp for compactness of implementation (may not be the most performant)
+    May also not play well with autograd (hopefully this doesn't matter)
+    """
+    # Prep
+    ishape = list(t.shape)
+    for i, (padleft, padright) in enumerate(zip(padding[::2], padding[1::2])):
+        ishape[-(i + 1)] -= padleft + padright
+
+    input_ = torch.zeros(*ishape, dtype=t.dtype, device=t.device)
+    f = partial(circular_pad, padding=padding)
+    t = vjp(f, inputs=input_, v=t, create_graph=True, strict=False)
+    return t[1]

--- a/src/torchlinops/functional/_interp/grid.py
+++ b/src/torchlinops/functional/_interp/grid.py
@@ -91,20 +91,21 @@ def _grid(
             output = torch.view_as_real(output).contiguous()
         grid = _get_grid()  # TODO
         BLOCK_WIDTH = get_block_width(width, ndim, is_complex)
-        GRID[ndim][grid](
-            vals,
-            locs,
-            output,
-            nbatch,
-            npts,
-            kernel,
-            norm,
-            is_complex,
-            *grid_size,
-            *width,
-            *BLOCK_WIDTH,
-            **kernel_params,
-        )
+        with torch.cuda.device(vals.device):
+            GRID[ndim][grid](
+                vals,
+                locs,
+                output,
+                nbatch,
+                npts,
+                kernel,
+                norm,
+                is_complex,
+                *grid_size,
+                *width,
+                *BLOCK_WIDTH,
+                **kernel_params,
+            )
         if is_complex:
             output = torch.view_as_complex(output)
     else:

--- a/src/torchlinops/functional/_interp/grid.py
+++ b/src/torchlinops/functional/_interp/grid.py
@@ -17,6 +17,7 @@ from .kernels import (
     get_kernel_fn,
     _apply_default_kernel_params,
     KernelTypeStr,
+    mod_pos,
 )
 from ._batch import batch_iterator
 
@@ -35,6 +36,7 @@ def grid(
     width: float | tuple[float, ...],
     kernel: str = "kaiser_bessel",
     norm: str = "1",
+    pad_mode: Literal["zero", "circular"] = "circular",
     kernel_params: dict = None,
 ):
     """Interpolate from off-grid values to on-grid locations.
@@ -57,6 +59,7 @@ def grid(
         locs,
         kernel=kernel,
         norm=norm,
+        pad_mode=pad_mode,
         kernel_params=kernel_params,
         **shapes,
     )
@@ -71,6 +74,7 @@ def _grid(
     width: tuple[float, ...],
     kernel: KernelTypeStr,
     norm: str,
+    pad_mode: str,
     ndim: int,
     nbatch: int,
     is_complex: bool,
@@ -89,7 +93,7 @@ def _grid(
         if is_complex:
             vals = torch.view_as_real(vals).contiguous()
             output = torch.view_as_real(output).contiguous()
-        grid = _get_grid()  # TODO
+        grid = _get_grid()
         BLOCK_WIDTH = get_block_width(width, ndim, is_complex)
         with torch.cuda.device(vals.device):
             GRID[ndim][grid](
@@ -100,6 +104,7 @@ def _grid(
                 npts,
                 kernel,
                 norm,
+                pad_mode,
                 is_complex,
                 *grid_size,
                 *width,
@@ -117,6 +122,7 @@ def _grid(
             width,
             kernel,
             norm,
+            pad_mode,
             **kernel_params,
         )
     return output
@@ -157,7 +163,8 @@ def _grid1d(
     npts,
     KERNEL: tl.constexpr,
     NORM: tl.constexpr,
-    is_complex,  # bool
+    PAD_MODE: tl.constexpr,
+    is_complex: tl.constexpr,  # bool
     x_size,
     x_kernel_width,
     X_BLOCK_WIDTH: tl.constexpr,
@@ -197,7 +204,10 @@ def _grid1d(
                 x_range_imag = 2 * x_range + 1
                 x_range_cplx = tl.join(x_range_real, x_range_imag)  # [width, 2]
                 x_mask_cplx = tl.join(x_mask, x_mask)
-                x_mask_cplx &= (x_range_cplx >= 0) & (x_range_cplx < (2 * x_size))
+                if PAD_MODE == "zero":
+                    x_mask_cplx &= (x_range_cplx >= 0) & (x_range_cplx < (2 * x_size))
+                elif PAD_MODE == "circular":
+                    x_range_cplx = mod_pos(x_range_cplx, 2 * x_size)
 
                 # Split and process separately
                 pt_real = tl.load(in_ptr + 2 * (in_batch_offset + p))
@@ -213,7 +223,10 @@ def _grid1d(
 
             else:
                 # Normal indexing
-                x_mask &= (x_range >= 0) & (x_range < x_size)
+                if PAD_MODE == "zero":
+                    x_mask &= (x_range >= 0) & (x_range < x_size)
+                elif PAD_MODE == "circular":
+                    x_range = mod_pos(x_range, x_size)
 
                 # Load
                 pt_val = tl.load(in_ptr + in_batch_offset + p)
@@ -239,7 +252,8 @@ def _grid2d(
     npts,
     KERNEL: tl.constexpr,
     NORM: tl.constexpr,
-    is_complex,  # bool
+    PAD_MODE: tl.constexpr,
+    is_complex: tl.constexpr,  # bool
     # Size of grid
     x_size,
     y_size,
@@ -291,14 +305,18 @@ def _grid2d(
             if is_complex:
                 x_range_cplx = x_range  # [width]
                 x_mask_cplx = x_mask
-                x_mask_cplx &= (x_range_cplx >= 0) & (x_range_cplx < x_size)
                 # Pytorch interleaved indexing
                 # Only applies to last dimension
                 y_range_real = 2 * y_range
                 y_range_imag = 2 * y_range + 1
                 y_range_cplx = tl.join(y_range_real, y_range_imag)  # [width, 2]
                 y_mask_cplx = tl.join(y_mask, y_mask)
-                y_mask_cplx &= (y_range_cplx >= 0) & (y_range_cplx < (2 * y_size))
+                if PAD_MODE == "zero":
+                    x_mask_cplx &= (x_range_cplx >= 0) & (x_range_cplx < x_size)
+                    y_mask_cplx &= (y_range_cplx >= 0) & (y_range_cplx < (2 * y_size))
+                elif PAD_MODE == "circular":
+                    x_range_cplx = mod_pos(x_range_cplx, x_size)
+                    y_range_cplx = mod_pos(y_range_cplx, 2 * y_size)
 
                 grid_range_cplx = (
                     x_range_cplx[:, None, None] * y_size * 2 + y_range_cplx[None, :, :]
@@ -322,8 +340,12 @@ def _grid2d(
 
             else:
                 # Normal indexing
-                x_mask &= (x_range >= 0) & (x_range < x_size)
-                y_mask &= (y_range >= 0) & (y_range < y_size)
+                if PAD_MODE == "zero":
+                    x_mask &= (x_range >= 0) & (x_range < x_size)
+                    y_mask &= (y_range >= 0) & (y_range < y_size)
+                elif PAD_MODE == "circular":
+                    x_range = mod_pos(x_range, x_size)
+                    y_range = mod_pos(y_range, y_size)
 
                 grid_range = x_range[:, None] * y_size + y_range[None, :]
                 grid_mask = x_mask[:, None] & y_mask[None, :]
@@ -352,7 +374,8 @@ def _grid3d(
     npts,
     KERNEL: tl.constexpr,
     NORM: tl.constexpr,
-    is_complex,  # bool
+    PAD_MODE: tl.constexpr,
+    is_complex: tl.constexpr,  # bool
     # Size of grid
     x_size,
     y_size,
@@ -414,15 +437,20 @@ def _grid3d(
                 y_range_cplx = y_range
                 x_mask_cplx = x_mask
                 y_mask_cplx = y_mask
-                x_mask_cplx &= (x_range_cplx >= 0) & (x_range_cplx < x_size)
-                y_mask_cplx &= (y_range_cplx >= 0) & (y_range_cplx < y_size)
                 # Pytorch interleaved indexing
                 # Only applies to last dimension
                 z_range_real = 2 * z_range  # 2 is for real/complex, not dimension
                 z_range_imag = 2 * z_range + 1
                 z_range_cplx = tl.join(z_range_real, z_range_imag)  # [width, 2]
                 z_mask_cplx = tl.join(z_mask, z_mask)
-                z_mask_cplx &= (z_range_cplx >= 0) & (z_range_cplx < (2 * z_size))
+                if PAD_MODE == "zero":
+                    x_mask_cplx &= (x_range_cplx >= 0) & (x_range_cplx < x_size)
+                    y_mask_cplx &= (y_range_cplx >= 0) & (y_range_cplx < y_size)
+                    z_mask_cplx &= (z_range_cplx >= 0) & (z_range_cplx < (2 * z_size))
+                elif PAD_MODE == "circular":
+                    x_range_cplx = mod_pos(x_range_cplx, x_size)
+                    y_range_cplx = mod_pos(y_range_cplx, y_size)
+                    z_range_cplx = mod_pos(z_range_cplx, 2 * z_size)
 
                 grid_range_cplx = (
                     x_range_cplx[:, None, None, None] * y_size
@@ -448,9 +476,14 @@ def _grid3d(
 
             else:
                 # Normal indexing
-                x_mask &= (x_range >= 0) & (x_range < x_size)
-                y_mask &= (y_range >= 0) & (y_range < y_size)
-                z_mask &= (z_range >= 0) & (z_range < z_size)
+                if PAD_MODE == "zero":
+                    x_mask &= (x_range >= 0) & (x_range < x_size)
+                    y_mask &= (y_range >= 0) & (y_range < y_size)
+                    z_mask &= (z_range >= 0) & (z_range < z_size)
+                elif PAD_MODE == "circular":
+                    x_range = mod_pos(x_range, x_size)
+                    y_range = mod_pos(y_range, y_size)
+                    z_range = mod_pos(z_range, z_size)
 
                 grid_range = (
                     x_range[:, None, None] * y_size + y_range[None, :, None]
@@ -467,14 +500,6 @@ def _grid3d(
 
                 # Accumulate
                 tl.atomic_add(out_ptr + out_batch_offset + grid_range, out, grid_mask)
-
-
-@triton.jit
-def get_neighborhood(target, kernel_width, base_range):
-    lower = target - (kernel_width / 2.0)
-    lower = tl.ceil(lower)
-    lower = tl.cast(lower, tl.int32)
-    return base_range + lower
 
 
 GRID = {1: _grid1d, 2: _grid2d, 3: _grid3d}
@@ -535,17 +560,16 @@ def grid_torch(
     width: tuple[float, ...],
     kernel: str = "kaiser_bessel",
     norm: str = "1",
+    pad_mode: Literal["zero", "circular"] = "circular",
     batch_size: int = 2**20,
-    padding: Literal["zero", "circular"] = "zero",
     **kernel_params,
 ):
     """Torch fallback
 
     Eventually, may want to use triton's CPU backend
 
-    padding : 'zero' or 'circular'
-        Type of edge padding to use
-        Triton kernels do zero padding by default
+    pad_mode : 'zero' or 'circular'
+        Type of edge behavior to use
     batch_size : int
         number of points to compute over at once
     """
@@ -584,7 +608,7 @@ def grid_torch(
             norm,
             kernel_fn,
             grid_size,
-            padding,
+            pad_mode,
         )
         val = vals[:, p0:p1, None]  # [nbatch, npts, 1]
         patches = weights * mask * val

--- a/src/torchlinops/functional/_interp/kernels.py
+++ b/src/torchlinops/functional/_interp/kernels.py
@@ -382,3 +382,9 @@ def get_neighborhood(target, kernel_width, base_range):
     lower = tl.ceil(lower)
     lower = tl.cast(lower, tl.int32)
     return base_range + lower
+
+
+@triton.jit
+def mod_pos(t, n):
+    """Modulo but ensures positive return value"""
+    return tl.where(t >= 0, t % n, (t % n) + n)

--- a/src/torchlinops/functional/_interp/tests/_valid_pts.py
+++ b/src/torchlinops/functional/_interp/tests/_valid_pts.py
@@ -3,13 +3,25 @@ import torch
 
 
 def get_valid_locs(
-    locs_batch_size, grid_size, ndim, width, device, centered: bool = False
+    locs_batch_size,
+    grid_size,
+    ndim,
+    width,
+    device,
+    centered: bool = False,
+    valid: bool = True,
 ):
-    """Avoid circular padding weirdness by sampling valid locations only"""
+    """Avoid circular padding weirdness by sampling valid locations only
+    Allow non-valid locations by setting valid=False
+    """
     out = []
     for d in range(ndim):
-        lower = ceil(width / 2)
-        upper = grid_size[d] - 1 - lower
+        if valid:
+            lower = ceil(width / 2)
+            upper = grid_size[d] - 1 - lower
+        else:
+            lower = 0
+            upper = grid_size[d] - 1
         locs = torch.rand(*locs_batch_size, device=device)
         locs = locs * (upper - lower) + lower
         out.append(locs)

--- a/src/torchlinops/functional/_interp/tests/bench_grid3d.py
+++ b/src/torchlinops/functional/_interp/tests/bench_grid3d.py
@@ -35,7 +35,7 @@ def main():
         # vals = torch.arange(prod(ishape)).reshape(ishape).to(dtype).to(device)
         vals = torch.randn(ishape, dtype=dtype, device=device)
         locs = get_valid_locs(npts, grid_size, ndim, width, device)
-        out = grid(vals, locs, grid_size, width, kernel)
+        out = grid(vals, locs, grid_size, width, kernel, pad_mode="circular")
         return out
 
     benchmark_and_summarize(

--- a/src/torchlinops/functional/_interp/tests/bench_ungrid3d.py
+++ b/src/torchlinops/functional/_interp/tests/bench_ungrid3d.py
@@ -35,7 +35,7 @@ def main():
         # vals = torch.arange(prod(ishape)).reshape(ishape).to(dtype).to(device)
         vals = torch.randn(ishape, dtype=dtype, device=device)
         locs = get_valid_locs(npts, grid_size, ndim, width, device)
-        out = ungrid(vals, locs, width, kernel, pad_mode="zero")
+        out = ungrid(vals, locs, width, kernel, pad_mode="circular")
         return out
 
     benchmark_and_summarize(

--- a/src/torchlinops/functional/_interp/tests/bench_ungrid3d.py
+++ b/src/torchlinops/functional/_interp/tests/bench_ungrid3d.py
@@ -35,7 +35,7 @@ def main():
         # vals = torch.arange(prod(ishape)).reshape(ishape).to(dtype).to(device)
         vals = torch.randn(ishape, dtype=dtype, device=device)
         locs = get_valid_locs(npts, grid_size, ndim, width, device)
-        out = ungrid(vals, locs, width, kernel)
+        out = ungrid(vals, locs, width, kernel, pad_mode="zero")
         return out
 
     benchmark_and_summarize(

--- a/src/torchlinops/functional/_interp/tests/test_circular_pad.py
+++ b/src/torchlinops/functional/_interp/tests/test_circular_pad.py
@@ -1,0 +1,53 @@
+import pytest
+
+import torch
+
+from torchlinops.functional._interp._circ_pad import circular_pad, circular_pad_adjoint
+from torchlinops.utils import inner
+
+
+def test_circular_pad_2d():
+    ishape = (15, 20)
+    x = torch.randn(*ishape)
+    padding = [4, 4, 2, 2]
+
+    y = circular_pad(x, padding)
+    assert y.shape == (19, 28)
+
+
+def test_circular_pad_nd():
+    ishape = (5, 15, 20, 19, 18)
+    x = torch.randn(*ishape)
+    padding = [1, 1, 2, 2, 3, 3, 5, 5]
+    y = circular_pad(x, padding)
+    assert y.shape == (5, 25, 26, 23, 20)
+
+
+def test_circular_pad_adjoint_1d():
+    ishape = (3,)
+    padding = [1, 1]
+    oshape = list(ishape)
+    for i, (padleft, padright) in enumerate(zip(padding[::2], padding[1::2])):
+        oshape[-(i + 1)] += padleft + padright
+    x = torch.randn(*ishape, dtype=torch.complex64)
+    y = torch.randn(*oshape, dtype=torch.complex64)
+
+    Ax = circular_pad(x, padding)
+    AHy = circular_pad_adjoint(y, padding)
+
+    assert torch.allclose(inner(x, AHy), inner(y, Ax).conj())
+
+
+def test_circular_pad_adjoint_2d():
+    ishape = (3, 3)
+    padding = [2, 2, 1, 1]
+    oshape = list(ishape)
+    for i, (padleft, padright) in enumerate(zip(padding[::2], padding[1::2])):
+        oshape[-(i + 1)] += padleft + padright
+    x = torch.randn(*ishape, dtype=torch.complex64)
+    y = torch.randn(*oshape, dtype=torch.complex64)
+
+    Ax = circular_pad(x, padding)
+    AHy = circular_pad_adjoint(y, padding)
+
+    assert torch.allclose(inner(x, AHy), inner(y, Ax).conj())

--- a/src/torchlinops/functional/_interp/tests/test_ungrid.py
+++ b/src/torchlinops/functional/_interp/tests/test_ungrid.py
@@ -19,6 +19,7 @@ PYTEST_GPU_MARKS = [
 
 # TODO add kernel type
 @pytest.mark.parametrize("kernel_type", ["kaiser_bessel", "spline"])
+@pytest.mark.parametrize("padding_mode", ["zero", "circular"])
 @pytest.mark.parametrize("dev", ["cpu", pytest.param("cuda", marks=PYTEST_GPU_MARKS)])
 @pytest.mark.parametrize("dtype", ["real", "complex"])
 @pytest.mark.parametrize(
@@ -36,7 +37,7 @@ PYTEST_GPU_MARKS = [
         pytest.param("large3d", marks=PYTEST_GPU_MARKS + [pytest.mark.slow]),
     ],
 )
-def test_ungrid(kernel_type, dev, dtype, spec, request):
+def test_ungrid(kernel_type, padding_mode, dev, dtype, spec, request):
     device = torch.device(dev)
     dtype = torch.complex64 if dtype == "complex" else torch.float32
     spec_name = spec
@@ -56,9 +57,20 @@ def test_ungrid(kernel_type, dev, dtype, spec, request):
     #     torch.rand(spec["npts"], device=device) + (w / 2 - 1) for d in range(ndim)
     # )
     # locs = torch.stack(locs, dim=-1).contiguous()
-    locs = get_valid_locs(locs_batch_size, grid_size, ndim, width, device)
+    if padding_mode == "zero":
+        locs = get_valid_locs(locs_batch_size, grid_size, ndim, width, device)
+    elif padding_mode == "circular":
+        locs = get_valid_locs(
+            locs_batch_size, grid_size, ndim, width, device, valid=False
+        )
 
-    interp = ungrid(vals, locs, width=width, kernel=kernel_type)
+    interp = ungrid(
+        vals,
+        locs,
+        width=width,
+        kernel=kernel_type,
+        pad_mode=padding_mode,
+    )
 
     # Test against sigpy
     vals = from_pytorch(vals)

--- a/src/torchlinops/functional/_interp/ungrid.py
+++ b/src/torchlinops/functional/_interp/ungrid.py
@@ -34,6 +34,7 @@ def ungrid(
     width: float | tuple[float, ...],
     kernel: str = "kaiser_bessel",
     norm: str = "1",
+    pad_mode: str = "circular",
     kernel_params: dict = None,
 ):
     """Interpolate from on-grid values to off-grid locations.
@@ -51,6 +52,7 @@ def ungrid(
         locs,
         kernel=kernel,
         norm=norm,
+        pad_mode=pad_mode,
         kernel_params=kernel_params,
         **shapes,
     )
@@ -65,6 +67,7 @@ def _ungrid(
     width: tuple[float, ...],
     kernel: KernelTypeStr,
     norm: str,
+    pad_mode: str,
     ndim: int,
     nbatch: int,
     is_complex: bool,
@@ -85,20 +88,22 @@ def _ungrid(
             output = torch.view_as_real(output).contiguous()
         grid = _get_grid()  # TODO
         BLOCK_WIDTH = get_block_width(width, ndim, is_complex)
-        UNGRID[ndim][grid](
-            vals,
-            locs,
-            output,
-            nbatch,
-            npts,
-            kernel,
-            norm,
-            is_complex,
-            *grid_size,
-            *width,
-            *BLOCK_WIDTH,
-            **kernel_params,
-        )
+        with torch.cuda.device(vals.device):
+            UNGRID[ndim][grid](
+                vals,
+                locs,
+                output,
+                nbatch,
+                npts,
+                kernel,
+                norm,
+                pad_mode,
+                is_complex,
+                *grid_size,
+                *width,
+                *BLOCK_WIDTH,
+                **kernel_params,
+            )
         if is_complex:
             output = torch.view_as_complex(output)
     else:
@@ -110,6 +115,7 @@ def _ungrid(
             width,
             kernel,
             norm,
+            pad_mode,
             **kernel_params,
         )
     return output
@@ -150,6 +156,7 @@ def _ungrid1d(
     npts,
     KERNEL: tl.constexpr,
     NORM: tl.constexpr,
+    PAD_MODE: tl.constexpr,
     is_complex,  # bool
     x_size,
     x_kernel_width,
@@ -190,7 +197,10 @@ def _ungrid1d(
                 x_range_imag = 2 * x_range + 1
                 x_range_cplx = tl.join(x_range_real, x_range_imag)  # [width, 2]
                 x_mask_cplx = tl.join(x_mask, x_mask)
-                x_mask_cplx &= (x_range_cplx >= 0) & (x_range_cplx < (2 * x_size))
+                if PAD_MODE == "zero":
+                    x_mask_cplx &= (x_range_cplx >= 0) & (x_range_cplx < (2 * x_size))
+                elif PAD_MODE == "circular":
+                    x_range_cplx = mod_pos(x_range_cplx, 2 * x_size)
 
                 # Load
                 grid_cplx = tl.load(
@@ -208,7 +218,10 @@ def _ungrid1d(
             else:
                 # Normal indexing
                 # x_range = x_base_range + x_nbhd
-                x_mask &= (x_range >= 0) & (x_range < x_size)
+                if PAD_MODE == "zero":
+                    x_mask &= (x_range >= 0) & (x_range < x_size)
+                elif PAD_MODE == "circular":
+                    x_range = mod_pos(x_range, x_size)
 
                 # Load
                 grid = tl.load(in_ptr + in_batch_offset + x_range, x_mask)
@@ -234,6 +247,7 @@ def _ungrid2d(
     npts,
     KERNEL: tl.constexpr,
     NORM: tl.constexpr,
+    PAD_MODE: tl.constexpr,
     is_complex,  # bool
     # Size of grid
     x_size,
@@ -286,14 +300,18 @@ def _ungrid2d(
             if is_complex:
                 x_range_cplx = x_range  # [width]
                 x_mask_cplx = x_mask
-                x_mask_cplx &= (x_range_cplx >= 0) & (x_range_cplx < x_size)
                 # Pytorch interleaved indexing
                 # Only applies to last dimension
                 y_range_real = 2 * y_range
                 y_range_imag = 2 * y_range + 1
                 y_range_cplx = tl.join(y_range_real, y_range_imag)  # [width, 2]
                 y_mask_cplx = tl.join(y_mask, y_mask)
-                y_mask_cplx &= (y_range_cplx >= 0) & (y_range_cplx < (2 * y_size))
+                if PAD_MODE == "zero":
+                    x_mask_cplx &= (x_range_cplx >= 0) & (x_range_cplx < x_size)
+                    y_mask_cplx &= (y_range_cplx >= 0) & (y_range_cplx < (2 * y_size))
+                elif PAD_MODE == "circular":
+                    x_range_cplx = mod_pos(x_range_cplx, x_size)
+                    y_range_cplx = mod_pos(y_range_cplx, 2 * y_size)
 
                 grid_range_cplx = (
                     x_range_cplx[:, None, None] * y_size * 2 + y_range_cplx[None, :, :]
@@ -314,8 +332,12 @@ def _ungrid2d(
 
             else:
                 # Normal indexing
-                x_mask &= (x_range >= 0) & (x_range < x_size)
-                y_mask &= (y_range >= 0) & (y_range < y_size)
+                if PAD_MODE == "zero":
+                    x_mask &= (x_range >= 0) & (x_range < x_size)
+                    y_mask &= (y_range >= 0) & (y_range < y_size)
+                elif PAD_MODE == "circular":
+                    x_range = mod_pos(x_range, x_size)
+                    y_range = mod_pos(y_range, y_size)
 
                 grid_range = x_range[:, None] * y_size + y_range[None, :]
                 grid_mask = x_mask[:, None] & y_mask[None, :]
@@ -344,6 +366,7 @@ def _ungrid3d(
     npts,
     KERNEL: tl.constexpr,
     NORM: tl.constexpr,
+    PAD_MODE: tl.constexpr,
     is_complex,  # bool
     # Size of grid
     x_size,
@@ -406,15 +429,20 @@ def _ungrid3d(
                 y_range_cplx = y_range
                 x_mask_cplx = x_mask
                 y_mask_cplx = y_mask
-                x_mask_cplx &= (x_range_cplx >= 0) & (x_range_cplx < x_size)
-                y_mask_cplx &= (y_range_cplx >= 0) & (y_range_cplx < y_size)
                 # Pytorch interleaved indexing
                 # Only applies to last dimension
                 z_range_real = 2 * z_range  # 2 is for real/complex, not dimension
                 z_range_imag = 2 * z_range + 1
                 z_range_cplx = tl.join(z_range_real, z_range_imag)  # [width, 2]
                 z_mask_cplx = tl.join(z_mask, z_mask)
-                z_mask_cplx &= (z_range_cplx >= 0) & (z_range_cplx < (2 * z_size))
+                if PAD_MODE == "zero":
+                    x_mask_cplx &= (x_range_cplx >= 0) & (x_range_cplx < x_size)
+                    y_mask_cplx &= (y_range_cplx >= 0) & (y_range_cplx < y_size)
+                    z_mask_cplx &= (z_range_cplx >= 0) & (z_range_cplx < (2 * z_size))
+                elif PAD_MODE == "circular":
+                    x_range_cplx = mod_pos(x_range_cplx, x_size)
+                    y_range_cplx = mod_pos(y_range_cplx, y_size)
+                    z_range_cplx = mod_pos(z_range_cplx, 2 * z_size)
 
                 grid_range_cplx = (
                     x_range_cplx[:, None, None, None] * y_size
@@ -438,9 +466,14 @@ def _ungrid3d(
 
             else:
                 # Normal indexing
-                x_mask &= (x_range >= 0) & (x_range < x_size)
-                y_mask &= (y_range >= 0) & (y_range < y_size)
-                z_mask &= (z_range >= 0) & (z_range < z_size)
+                if PAD_MODE == "zero":
+                    x_mask &= (x_range >= 0) & (x_range < x_size)
+                    y_mask &= (y_range >= 0) & (y_range < y_size)
+                    z_mask &= (z_range >= 0) & (z_range < z_size)
+                elif PAD_MODE == "circular":
+                    x_range = mod_pos(x_range, x_size)
+                    y_range = mod_pos(y_range, y_size)
+                    z_range = mod_pos(z_range, z_size)
 
                 grid_range = (
                     x_range[:, None, None] * y_size + y_range[None, :, None]
@@ -465,6 +498,12 @@ def get_neighborhood(target, kernel_width, base_range):
     lower = tl.ceil(lower)
     lower = tl.cast(lower, tl.int32)
     return base_range + lower
+
+
+@triton.jit
+def mod_pos(t, n):
+    """Modulo but ensures positive return value"""
+    return tl.where(t >= 0, t % n, (t % n) + n)
 
 
 UNGRID = {1: _ungrid1d, 2: _ungrid2d, 3: _ungrid3d}
@@ -523,16 +562,16 @@ def ungrid_torch(
     width: tuple[float, ...],
     kernel: str = "kaiser_bessel",
     norm: str = "1",
+    pad_mode: Literal["zero", "circular"] = "zero",
     batch_size: int = 2**20,
-    padding: Literal["zero", "circular"] = "zero",
     **kernel_params,
 ):
     """Torch fallback
 
     Eventually, may want to use triton's CPU backend
 
-    padding : 'zero' or 'circular'
-        Type of edge padding to use
+    pad_mode : 'zero' or 'circular'
+        Type of edge behavior to use
         Triton kernels do zero padding by default
     batch size : int
         number of points to compute over at once
@@ -572,7 +611,7 @@ def ungrid_torch(
             norm,
             kernel_fn,
             grid_size,
-            padding,
+            pad_mode,
         )
         grid_locs = (slice(None), *tuple(grid_locs[..., i] for i in range(ndim)))
         out[:, p0:p1] = torch.sum(weights * vals[grid_locs] * mask, dim=-1)

--- a/src/torchlinops/linops/pad_last.py
+++ b/src/torchlinops/linops/pad_last.py
@@ -13,7 +13,7 @@ __all__ = ["PadLast"]
 
 
 class PadLast(NamedLinop):
-    """Pad the last dimensions of the input volume
+    """Zero Pad the last dimensions of the input volume
     ishape: [B... Nx Ny [Nz]]
     oshape: [B... Nx1 Ny1 [Nz1]]
 

--- a/src/torchlinops/utils/_fft.py
+++ b/src/torchlinops/utils/_fft.py
@@ -1,9 +1,10 @@
+from torch import Tensor
 import torch.fft as fft
 
-__all__ = ["cfft", "cifft"]
+__all__ = ["cfft", "cifft", "cfft2", "cifft2", "cfftn", "cifftn"]
 
 
-def cfft(x, dim=None, norm="ortho"):
+def cfftn(x, dim=None, norm="ortho"):
     """Matches Sigpy's fft, but in torch
     c = centered
     """
@@ -13,9 +14,26 @@ def cfft(x, dim=None, norm="ortho"):
     return x
 
 
-def cifft(x, dim=None, norm="ortho"):
+def cifftn(x, dim=None, norm="ortho"):
     """Matches Sigpy's fft adjoint, but in torch"""
     x = fft.ifftshift(x, dim=dim)
     x = fft.ifftn(x, dim=dim, norm=norm)
     x = fft.fftshift(x, dim=dim)
     return x
+
+
+# Convenience functions
+def cfft(x: Tensor, **kwargs):
+    return cfftn(x, dim=(-1,), **kwargs)
+
+
+def cifft(x: Tensor, **kwargs):
+    return cifftn(x, dim=(-1,), **kwargs)
+
+
+def cfft2(x: Tensor, **kwargs):
+    return cfftn(x, dim=(-2, -1), **kwargs)
+
+
+def cifft2(x: Tensor, **kwargs):
+    return cifftn(x, dim=(-2, -1), **kwargs)

--- a/src/torchlinops/utils/_log.py
+++ b/src/torchlinops/utils/_log.py
@@ -43,7 +43,7 @@ class Indenter:
         return text
 
     def print(self, text):
-        print(self.format(text))
+        print(self.indent(text))
 
     def __enter__(self):
         self.level += 1


### PR DESCRIPTION
### New Circular Padding Functionality:
* Added `circular_pad`,, and `circular_pad_adjoint` functions and tests to handle circular padding for tensors. (`src/torchlinops/functional/_interp/_circ_pad.py`) (`src/torchlinops/functional/_interp/tests/test_circular_pad.py`)

### Circular Padding into Grid Interpolation:
Note: implementation here is fundamentally different than the `circular_pad` functions.

* Updated the `grid` and `grid_torch` functions to include a `pad_mode` parameter, allowing users to choose between "zero" and "circular" padding. (`src/torchlinops/functional/_interp/grid.py`) [[1]](diffhunk://#diff-7aa9263a3fac7c0e13471d379434f18eb3f28b582f6bb761dbdd0da02606b33eR39) [[2]](diffhunk://#diff-7aa9263a3fac7c0e13471d379434f18eb3f28b582f6bb761dbdd0da02606b33eR62) [[3]](diffhunk://#diff-7aa9263a3fac7c0e13471d379434f18eb3f28b582f6bb761dbdd0da02606b33eR77) [[4]](diffhunk://#diff-7aa9263a3fac7c0e13471d379434f18eb3f28b582f6bb761dbdd0da02606b33eR125) [[5]](diffhunk://#diff-7aa9263a3fac7c0e13471d379434f18eb3f28b582f6bb761dbdd0da02606b33eR563-R572) [[6]](diffhunk://#diff-7aa9263a3fac7c0e13471d379434f18eb3f28b582f6bb761dbdd0da02606b33eL586-R611)
* Modified the `_grid1d`, `_grid2d`, and `_grid3d` functions to handle the new `pad_mode` parameter, implementing the logic for circular padding. (`src/torchlinops/functional/_interp/grid.py`) [[1]](diffhunk://#diff-7aa9263a3fac7c0e13471d379434f18eb3f28b582f6bb761dbdd0da02606b33eR207-R210) [[2]](diffhunk://#diff-7aa9263a3fac7c0e13471d379434f18eb3f28b582f6bb761dbdd0da02606b33eR226-R229) [[3]](diffhunk://#diff-7aa9263a3fac7c0e13471d379434f18eb3f28b582f6bb761dbdd0da02606b33eL293-R319) [[4]](diffhunk://#diff-7aa9263a3fac7c0e13471d379434f18eb3f28b582f6bb761dbdd0da02606b33eR343-R348) [[5]](diffhunk://#diff-7aa9263a3fac7c0e13471d379434f18eb3f28b582f6bb761dbdd0da02606b33eL416-R453) [[6]](diffhunk://#diff-7aa9263a3fac7c0e13471d379434f18eb3f28b582f6bb761dbdd0da02606b33eR479-R486)
* Updated existing grid interpolation tests to include the new `pad_mode` parameter, ensuring both "zero" and "circular" padding modes are tested. (`src/torchlinops/functional/_interp/tests/test_grid.py`) [[1]](diffhunk://#diff-7c2880d1bd8fde1c918511ec8661b49a6979b4b49b007396b684d743d0f70c10R22) [[2]](diffhunk://#diff-7c2880d1bd8fde1c918511ec8661b49a6979b4b49b007396b684d743d0f70c10L39-R40)