### PR TITLE
Adding pad_mode to interp autograd

### DIFF
--- a/src/torchlinops/functional/_interp/interp.py
+++ b/src/torchlinops/functional/_interp/interp.py
@@ -22,17 +22,18 @@ class InterpolateFn(Function):
         width: float | tuple[float, ...],
         kernel: str,
         norm: str,
+        pad_mode: str,
         kernel_params: dict,
     ) -> Tensor:
         """Remembered something about Function not liking type annotations?"""
-        output = ungrid(vals, locs, width, kernel, norm, kernel_params)
+        output = ungrid(vals, locs, width, kernel, norm, pad_mode, kernel_params)
         output.requires_grad_(vals.requires_grad)
         return output
 
     @staticmethod
     def setup_context(ctx, inputs, output):
         # Unpack input and output
-        vals, locs, width, kernel, norm, kernel_params = inputs
+        vals, locs, width, kernel, norm, pad_mode, kernel_params = inputs
 
         # Save for backward pass
         ndim = locs.shape[-1]
@@ -40,16 +41,16 @@ class InterpolateFn(Function):
         ctx.width = width
         ctx.kernel = kernel
         ctx.norm = norm
+        ctx.pad_mode = pad_mode
         ctx.kernel_params = kernel_params
         ctx.save_for_backward(locs)
 
     @staticmethod
     def backward(ctx, grad_output):
         """"""
-        grad_vals = grad_locs = grad_width = grad_kernel = grad_norm = (
+        grad_vals = grad_locs = grad_width = grad_kernel = grad_norm = grad_pad_mode = (
             grad_kernel_params
         ) = None
-
         if ctx.needs_input_grad[0]:
             locs = ctx.saved_tensors[0]
             grad_vals = grid(
@@ -59,6 +60,7 @@ class InterpolateFn(Function):
                 ctx.width,
                 ctx.kernel,
                 ctx.norm,
+                ctx.pad_mode,
                 ctx.kernel_params,
             )
         return (
@@ -67,6 +69,7 @@ class InterpolateFn(Function):
             grad_width,
             grad_kernel,
             grad_norm,
+            grad_pad_mode,
             grad_kernel_params,
         )
 
@@ -77,10 +80,11 @@ def interpolate(
     width: float | tuple[float, ...],
     kernel="kaiser_bessel",
     norm: str = "1",
+    pad_mode: str = "circular",
     kernel_params: dict = None,
 ):
     """Wrapper for default arguments"""
-    return InterpolateFn.apply(vals, locs, width, kernel, norm, kernel_params)
+    return InterpolateFn.apply(vals, locs, width, kernel, norm, pad_mode, kernel_params)
 
 
 class InterpolateAdjointFn(Function):
@@ -94,20 +98,31 @@ class InterpolateAdjointFn(Function):
         width: float | tuple[float, ...],
         kernel: str,
         norm: str,
+        pad_mode: str,
         kernel_params: dict,
     ) -> Tensor:
-        output = grid(vals, locs, grid_size, width, kernel, norm, kernel_params)
+        output = grid(
+            vals,
+            locs,
+            grid_size,
+            width,
+            kernel,
+            norm,
+            pad_mode,
+            kernel_params,
+        )
         output.requires_grad_(vals.requires_grad)
         return output
 
     @staticmethod
     def setup_context(ctx, inputs, output):
-        vals, locs, grid_size, width, kernel, norm, kernel_params = inputs
+        vals, locs, grid_size, width, kernel, norm, pad_mode, kernel_params = inputs
 
         # Save for backward pass
         ctx.width = width
         ctx.kernel = kernel
         ctx.norm = norm
+        ctx.pad_mode = pad_mode
         ctx.kernel_params = kernel_params
         ctx.save_for_backward(locs)
 
@@ -115,7 +130,7 @@ class InterpolateAdjointFn(Function):
     def backward(ctx, grad_output):
         grad_vals = grad_locs = grad_grid_size = grad_width = grad_kernel = (
             grad_norm
-        ) = grad_kernel_params = None
+        ) = grad_pad_mode = grad_kernel_params = None
         if ctx.needs_input_grad[0]:
             locs = ctx.saved_tensors[0]
             grad_vals = ungrid(
@@ -124,6 +139,7 @@ class InterpolateAdjointFn(Function):
                 ctx.width,
                 ctx.kernel,
                 ctx.norm,
+                ctx.pad_mode,
                 ctx.kernel_params,
             )
         return (
@@ -133,6 +149,7 @@ class InterpolateAdjointFn(Function):
             grad_width,
             grad_kernel,
             grad_norm,
+            grad_pad_mode,
             grad_kernel_params,
         )
 
@@ -144,9 +161,17 @@ def interpolate_adjoint(
     width: float | tuple[float, ...],
     kernel: str = "kaiser_bessel",
     norm: str = "1",
+    pad_mode: str = "circular",
     kernel_params: dict = None,
 ):
     """Wrapper for default arguments"""
     return InterpolateAdjointFn.apply(
-        vals, locs, grid_size, width, kernel, norm, kernel_params
+        vals,
+        locs,
+        grid_size,
+        width,
+        kernel,
+        norm,
+        pad_mode,
+        kernel_params,
     )

--- a/src/torchlinops/linops/interp.py
+++ b/src/torchlinops/linops/interp.py
@@ -27,6 +27,7 @@ class Interpolate(NamedLinop):
         width: float = 4.0,
         kernel: str = "kaiser_bessel",
         norm: str = "1",
+        pad_mode: str = "circular",
         **kernel_params,
     ):
         batch_shape = default_to(("...",), batch_shape)
@@ -45,6 +46,7 @@ class Interpolate(NamedLinop):
             "width": width,
             "kernel": kernel,
             "norm": norm,
+            "pad_mode": pad_mode,
             "kernel_params": kernel_params,
         }
 

--- a/src/torchlinops/tests/test_einops.py
+++ b/src/torchlinops/tests/test_einops.py
@@ -11,6 +11,8 @@ from torchlinops.tests.test_base import BaseNamedLinopTests
 class TestSumReduce(BaseNamedLinopTests):
     equality_check = "approx"
 
+    isclose_kwargs = {"rtol": 1e-4}
+
     @pytest.fixture(scope="class", params=["fullshape", "ellipses"])
     def linop_input_output(self, request):
         x = torch.randn(5, 2, 3)


### PR DESCRIPTION
Quick fix (copilot summary below)

### Functional Changes:
* Added `pad_mode` parameter to the `forward` and `backward` methods in `src/torchlinops/functional/_interp/interp.py` and updated their implementations to handle this new parameter. [[1]](diffhunk://#diff-7c220524039a99acaebddb518ebd9cae3a39a29758a959ab8216b29a09fbd20cR25-L52) [[2]](diffhunk://#diff-7c220524039a99acaebddb518ebd9cae3a39a29758a959ab8216b29a09fbd20cR63) [[3]](diffhunk://#diff-7c220524039a99acaebddb518ebd9cae3a39a29758a959ab8216b29a09fbd20cR72) [[4]](diffhunk://#diff-7c220524039a99acaebddb518ebd9cae3a39a29758a959ab8216b29a09fbd20cR101-R133) [[5]](diffhunk://#diff-7c220524039a99acaebddb518ebd9cae3a39a29758a959ab8216b29a09fbd20cR142) [[6]](diffhunk://#diff-7c220524039a99acaebddb518ebd9cae3a39a29758a959ab8216b29a09fbd20cR152)
* Updated the `interpolate` and `interpolate_adjoint` functions to include the `pad_mode` parameter with a default value of `"circular"`. [[1]](diffhunk://#diff-7c220524039a99acaebddb518ebd9cae3a39a29758a959ab8216b29a09fbd20cR83-R87) [[2]](diffhunk://#diff-7c220524039a99acaebddb518ebd9cae3a39a29758a959ab8216b29a09fbd20cR164-R176)

### Class Initialization:
* Modified the `__init__` method in `src/torchlinops/linops/interp.py` to accept the `pad_mode` parameter and include it in the initialization dictionary. [[1]](diffhunk://#diff-88d6c241ca253522e7b6bd71e8786c23d4ace08413d204f5f08ccc608a275b4dR30) [[2]](diffhunk://#diff-88d6c241ca253522e7b6bd71e8786c23d4ace08413d204f5f08ccc608a275b4dR49)