### PR TITLE
0.3.21

### DIFF
--- a/src/torchlinops/__init__.py
+++ b/src/torchlinops/__init__.py
@@ -1,4 +1,4 @@
 from .alg import *
 from .linops import *
 
-__version__ = "0.3.20"
+__version__ = "0.3.21"

--- a/src/torchlinops/alg/powermethod.py
+++ b/src/torchlinops/alg/powermethod.py
@@ -43,6 +43,7 @@ def power_method(
         v = v_init.clone()
 
     # Initialize
+    A.to(device)
     vnorm = torch.linalg.vector_norm(v, dim=dim, keepdim=True)
     v = v / (vnorm + eps)
     pbar = tqdm(range(max_iters), total=max_iters, **tqdm_kwargs)

--- a/src/torchlinops/functional/_interp/grid.py
+++ b/src/torchlinops/functional/_interp/grid.py
@@ -51,12 +51,6 @@ def grid(
         if 1, computes weights as product of axis-aligned norm weights
             - Same as sigpy
     """
-    # Check for contiguity
-    if not vals.is_contiguous() and locs.is_contiguous():
-        raise ValueError(
-            f"Both vals and locs should be contiguous but got vals.is_contiguous()={vals.is_contiguous()} and locs.is_contiguous()={locs.is_contiguous()}"
-        )
-
     kernel_params = {} if kernel_params is None else kernel_params
     vals_flat, locs, shapes = prep_grid_shapes(vals, locs, grid_size, width)
     kernel_params = _apply_default_kernel_params(kernel, kernel_params)
@@ -90,6 +84,10 @@ def _grid(
     **kwargs,
 ):
     if vals.is_cuda and ndim in GRID.keys():
+        # Ensure contiguity
+        vals = vals.contiguous()
+        locs = locs.contiguous()
+        # Preallocate output
         output = torch.zeros(
             nbatch,
             *grid_size,

--- a/src/torchlinops/functional/_interp/ungrid.py
+++ b/src/torchlinops/functional/_interp/ungrid.py
@@ -45,11 +45,6 @@ def ungrid(
         if 1, computes weights as product of axis-aligned norm weights
             - Same as sigpy
     """
-    # Check for contiguity
-    if not vals.is_contiguous() and locs.is_contiguous():
-        raise ValueError(
-            f"Both vals and locs should be contiguous but got vals.is_contiguous()={vals.is_contiguous()} and locs.is_contiguous()={locs.is_contiguous()}"
-        )
 
     kernel_params = {} if kernel_params is None else kernel_params
     vals_flat, locs, shapes = prep_ungrid_shapes(vals, locs, width)
@@ -84,6 +79,10 @@ def _ungrid(
     **kwargs,
 ):
     if vals.is_cuda and ndim in UNGRID.keys():
+        # Ensure contiguity
+        vals = vals.contiguous()
+        locs = locs.contiguous()
+        # Preallocate output
         output = torch.zeros(
             nbatch,
             *locs_batch_shape,

--- a/src/torchlinops/linops/batch.py
+++ b/src/torchlinops/linops/batch.py
@@ -6,6 +6,7 @@ import traceback
 from pprint import pformat
 
 import torch
+import torch.nn as nn
 from tqdm import tqdm
 
 from .namedlinop import NamedLinop
@@ -58,7 +59,8 @@ class Batch(NamedLinop):
         self._linops = None
         self.batch_sizes = {ND.infer(k): v for k, v in self.batch_sizes.items()}
         self.sizes = self._precompute_sizes()
-        self._linops, self._input_batches, self._output_batches = self.make_tiles()
+        _linops, self._input_batches, self._output_batches = self.make_tiles()
+        self._linops = nn.ModuleList(_linops)
         self._shape = NS(self.linop.ishape, self.linop.oshape)
         super().reset_adjoint_and_normal()
         if self.post_batch_hook is not None:

--- a/src/torchlinops/linops/diagonal.py
+++ b/src/torchlinops/linops/diagonal.py
@@ -19,7 +19,7 @@ class Diagonal(NamedLinop):
         self,
         weight: torch.Tensor,
         ioshape: Shape,
-        broadcast_dims: Optional[list[str]] = None,
+        broadcast_dims: Optional[Shape] = None,
     ):
         if len(weight.shape) > len(ioshape):
             raise ValueError(

--- a/src/torchlinops/linops/diagonal.py
+++ b/src/torchlinops/linops/diagonal.py
@@ -1,7 +1,7 @@
 from typing import Optional
 from torch import Tensor
 
-from copy import copy, deepcopy
+from copy import copy
 from warnings import warn
 
 from einops import repeat
@@ -96,21 +96,27 @@ class Diagonal(NamedLinop):
         return x * torch.abs(weight) ** 2
 
     def adjoint(self):
-        adj = deepcopy(self)
-        adj.weight.data = self.weight.conj()
+        adj = copy(self)
+        adj.weight = nn.Parameter(
+            self.weight.conj(),
+            requires_grad=self.weight.requires_grad,
+        )
         return adj
 
     def normal(self, inner=None):
         if inner is None:
-            normal = deepcopy(self)
-            normal.weight.data = torch.abs(self.weight) ** 2
+            normal = copy(self)
+            normal.weight = nn.Parameter(
+                torch.abs(self.weight) ** 2,
+                requires_grad=self.weight.requires_grad,
+            )
             return normal
         return super().normal(inner)
 
     def split_forward(self, ibatch, obatch):
         weight = self.split_forward_fn(ibatch, obatch, self.weight)
-        split = deepcopy(self)
-        split.weight.data = weight
+        split = copy(self)
+        split.weight = nn.Parameter(weight, requires_grad=self.weight.requires_grad)
         return split
 
     def split_forward_fn(self, ibatch, obatch, /, weight):
@@ -135,6 +141,9 @@ class Diagonal(NamedLinop):
         return None
 
     def __pow__(self, exponent):
-        new = deepcopy(self)
-        new.weight.data = self.weight**exponent
+        new = copy(self)
+        new.weight = nn.Parameter(
+            self.weight**exponent,
+            requires_grad=self.weight.requires_grad,
+        )
         return new

--- a/src/torchlinops/linops/interp.py
+++ b/src/torchlinops/linops/interp.py
@@ -7,7 +7,7 @@ from warnings import warn
 import torch.nn as nn
 
 import torchlinops.functional as F
-from torchlinops.utils import default_to
+from torchlinops.utils import default_to, default_to_dict
 
 from .namedlinop import NamedLinop
 from .nameddim import ELLIPSES, NS, Shape
@@ -28,7 +28,7 @@ class Interpolate(NamedLinop):
         kernel: str = "kaiser_bessel",
         norm: str = "1",
         pad_mode: str = "circular",
-        **kernel_params,
+        kernel_params: Optional[dict] = None,
     ):
         batch_shape = default_to(("...",), batch_shape)
         locs_batch_shape = default_to(("...",), locs_batch_shape)
@@ -42,6 +42,7 @@ class Interpolate(NamedLinop):
         self.grid_size = grid_size
 
         # Do this here instead of repeating it in both fn() and adjoint_fn()
+        kernel_params = default_to_dict(dict(beta=1.0), kernel_params)
         self._interp_params = {
             "width": width,
             "kernel": kernel,

--- a/src/torchlinops/linops/nameddim/_nameddim.py
+++ b/src/torchlinops/linops/nameddim/_nameddim.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from copy import copy
 from dataclasses import dataclass
 from typing import Any, Tuple, List
@@ -10,7 +12,7 @@ ANY = "()"
 
 
 # Convenience function
-def parse_dim_str(s: str) -> tuple[str]:
+def parse_dim_str(s: Optional[str] = None) -> tuple[str]:
     """
     Rules:
     - dim begins with an uppercase letter
@@ -25,7 +27,7 @@ def parse_dim_str(s: str) -> tuple[str]:
     >>> parse_dim_str("A1B2Kx1Ky2")
     ('A1', 'B2', 'Kx1', 'Ky2')
     """
-    if len(s) == 0:
+    if s is None or len(s) == 0:
         return tuple()
     parts = []
     current = s[0]

--- a/src/torchlinops/linops/namedlinop.py
+++ b/src/torchlinops/linops/namedlinop.py
@@ -10,7 +10,7 @@ import torch.nn as nn
 
 import torchlinops
 
-from .nameddim import NamedDimension as ND, NamedShape, NS
+from .nameddim import NamedDimension as ND, NamedShape, NS, NDorStr
 from torchlinops.utils import INDENT
 
 __all__ = ["NamedLinop"]
@@ -247,13 +247,13 @@ class NamedLinop(nn.Module):
 
     def __mul__(self, right):
         if isinstance(right, float) or isinstance(right, torch.Tensor):
-            right = torchlinops.Scalar(weight=right)
+            right = torchlinops.Scalar(weight=right, ioshape=self.ishape)
             return self.compose(right)
         return NotImplemented
 
     def __rmul__(self, left):
         if isinstance(left, float) or isinstance(left, torch.Tensor):
-            left = torchlinops.Scalar(weight=left)
+            left = torchlinops.Scalar(weight=left, ioshape=self.oshape)
             return left.compose(self)
         return NotImplemented
 

--- a/src/torchlinops/linops/nufft.py
+++ b/src/torchlinops/linops/nufft.py
@@ -57,7 +57,6 @@ class NUFFT(Chain):
         # Initialize variables
         ndim = len(grid_size)
         padded_size = [int(i * oversamp) for i in grid_size]
-        beta = self.beta(width, oversamp)
 
         # Create Padding
         pad = PadLast(
@@ -88,6 +87,7 @@ class NUFFT(Chain):
             torch.tensor(padded_size, device=device) - 1,
         )
         if mode == "interpolate":
+            beta = self.beta(width, oversamp)
             # Create Apodization
             weight = self._apodize_weights(
                 grid_size, padded_size, oversamp, width, beta
@@ -104,7 +104,7 @@ class NUFFT(Chain):
                 grid_shape=grid_shape,
                 width=width,
                 kernel="kaiser_bessel",
-                beta=beta,
+                kernel_params=dict(beta=beta),
             )
             # Create scaling
             scale_factor = width**ndim * (prod(grid_size) / prod(padded_size)) ** 0.5

--- a/src/torchlinops/linops/pad_last.py
+++ b/src/torchlinops/linops/pad_last.py
@@ -14,6 +14,8 @@ __all__ = ["PadLast"]
 
 class PadLast(NamedLinop):
     """Zero Pad the last dimensions of the input volume
+    Padding is centered:
+    - TODO: support non-centered padding?
     ishape: [B... Nx Ny [Nz]]
     oshape: [B... Nx1 Ny1 [Nz1]]
 

--- a/src/torchlinops/linops/sampling.py
+++ b/src/torchlinops/linops/sampling.py
@@ -46,10 +46,10 @@ class Sampling(NamedLinop):
         self.register_shape("input_shape", input_shape)
         self.register_shape("output_shape", output_shape)
         self.register_shape("batch_shape", batch_shape)
-        if len(output_shape) != len(idx):
-            raise ValueError(
-                f"Output shape {output_shape} doesn't correspond to idx with shape {len(idx)}"
-            )
+        # if len(input_shape) != len(idx):
+        #     raise ValueError(
+        #         f"Input shape {input_shape} doesn't correspond to idx with shape {len(idx)}"
+        #     )
         idx = ensure_tensor_indexing(idx, self.input_size)
         for d, (t, s) in enumerate(zip(idx, self.input_size)):
             if (t < 0).any() or (t >= s).any():
@@ -94,7 +94,7 @@ class Sampling(NamedLinop):
         )
 
     def split_forward_fn(self, ibatch, obatch, idx):
-        nM = len(idx)
+        nM = len(idx[0].shape)
         if nM > 0:
             idx_slc = list(obatch[-nM:])
             return [i[idx_slc] for i in idx]

--- a/src/torchlinops/tests/test_nufft.py
+++ b/src/torchlinops/tests/test_nufft.py
@@ -112,7 +112,7 @@ def test_apodize(nufft_params):
     padded_size = nufft_params["padded_size"]
 
     beta = NUFFT.beta(width, oversamp)
-    apod = NUFFT._apodize_weights(grid_size, padded_size, oversamp, width, beta)
+    apod = NUFFT.apodize_weights(grid_size, padded_size, oversamp, width, beta)
 
     x = np.ones(grid_size)
     apod_sp = sp.fourier._apodize(x, len(grid_size), oversamp, width, beta)

--- a/src/torchlinops/tests/test_nufft.py
+++ b/src/torchlinops/tests/test_nufft.py
@@ -166,7 +166,7 @@ def test_nufft_interp(nufft_params):
         grid_shape=None,
         width=width,
         kernel="kaiser_bessel",
-        beta=beta,
+        kernel_params=dict(beta=beta),
     )
 
     x = torch.randn(*padded_size, dtype=torch.complex64)

--- a/src/torchlinops/tests/test_nufft.py
+++ b/src/torchlinops/tests/test_nufft.py
@@ -139,7 +139,7 @@ def test_scale_locs(nufft_params):
 
     # Torch version
     locs = nufft_params["locs"]
-    locs_scaled = NUFFT.scale_and_shift_locs(locs, grid_size, padded_size)
+    locs_scaled = NUFFT.prep_locs(locs, grid_size, padded_size)
 
     coord = locs.clone().numpy()
     sz = np.array(grid_size)
@@ -155,11 +155,9 @@ def test_nufft_interp(nufft_params):
     oversamp = nufft_params["oversamp"]
     beta = NUFFT.beta(width, oversamp)
 
-    locs_scaled_shifted = NUFFT.scale_and_shift_locs(
-        locs.clone(), grid_size, padded_size
-    )
+    locs_prepared = NUFFT.prep_locs(locs.clone(), grid_size, padded_size)
     interp = Interpolate(
-        locs_scaled_shifted,
+        locs_prepared,
         padded_size,
         batch_shape=None,
         locs_batch_shape=None,
@@ -174,7 +172,7 @@ def test_nufft_interp(nufft_params):
 
     interpx_sp = sp.interp.interpolate(
         x.numpy(),
-        locs_scaled_shifted.numpy(),
+        locs_prepared.numpy(),
         kernel="kaiser_bessel",
         width=width,
         param=beta,


### PR DESCRIPTION
See copilot summary below:

### Contiguity (`functional`, `grid`/`ungrid`)
* Removed contiguity checks in the `grid` and `ungrid` functions and added contiguity enforcement in their respective `_grid` and `_ungrid` helper functions in `src/torchlinops/functional/_interp/grid.py` and `src/torchlinops/functional/_interp/ungrid.py`. [[1]](diffhunk://#diff-7aa9263a3fac7c0e13471d379434f18eb3f28b582f6bb761dbdd0da02606b33eL54-L59) [[2]](diffhunk://#diff-7aa9263a3fac7c0e13471d379434f18eb3f28b582f6bb761dbdd0da02606b33eR87-R90) [[3]](diffhunk://#diff-03515020f226a036489583f8f00df491e839829908f75735e66d8fc60adfac60L48-L52) [[4]](diffhunk://#diff-03515020f226a036489583f8f00df491e839829908f75735e66d8fc60adfac60R82-R85)

### Batch
* Allow `.to(device)` to propagate to linops in `Batch` by updating `setup_batching` method to use `nn.ModuleList` for `_linops`. [[1]](diffhunk://#diff-864b1306377969fa8f4b230efdf90fc768333da3e82f30f4e64e3837ce8f5bbcR9) [[2]](diffhunk://#diff-864b1306377969fa8f4b230efdf90fc768333da3e82f30f4e64e3837ce8f5bbcL61-R63)

### Diagonal
* Changed the type of `broadcast_dims` parameter from `list[str]` to `Shape` in `src/torchlinops/linops/diagonal.py` and replaced `deepcopy` with `copy` for `weight` handling. [[1]](diffhunk://#diff-4df0882e8930f636fcdc1ee436d5a95677f533be800747c5c5240dcdf230f301L22-R22) [[2]](diffhunk://#diff-4df0882e8930f636fcdc1ee436d5a95677f533be800747c5c5240dcdf230f301L99-R119) [[3]](diffhunk://#diff-4df0882e8930f636fcdc1ee436d5a95677f533be800747c5c5240dcdf230f301L138-R148)

### Interpolate
* Updated `kernel_params` parameter handling in `src/torchlinops/linops/interp.py` to use `default_to_dict`. [[1]](diffhunk://#diff-88d6c241ca253522e7b6bd71e8786c23d4ace08413d204f5f08ccc608a275b4dL31-R31) [[2]](diffhunk://#diff-88d6c241ca253522e7b6bd71e8786c23d4ace08413d204f5f08ccc608a275b4dR45)

### NUFFT
* Added parameters `do_prep_locs` and `apodize_weights` to `NUFFT` initialization in `src/torchlinops/linops/nufft.py` and updated related methods for better memory management and flexibility. [[1]](diffhunk://#diff-ceda08d3516aac65de0d275621615b0f5f995c2b7bad04a94bedb930b9dc7b41R42-R59) [[2]](diffhunk://#diff-ceda08d3516aac65de0d275621615b0f5f995c2b7bad04a94bedb930b9dc7b41L81-R129) [[3]](diffhunk://#diff-ceda08d3516aac65de0d275621615b0f5f995c2b7bad04a94bedb930b9dc7b41L149-R187) [[4]](diffhunk://#diff-ceda08d3516aac65de0d275621615b0f5f995c2b7bad04a94bedb930b9dc7b41L182-R203)
* Fixed scaling/rounding/clipping issues in `prep_locs` that were affecting the NUFFT in `Sampling` mode.

### Misc
* Added support for optional string parsing in `parse_dim_str` function in `src/torchlinops/linops/nameddim/_nameddim.py`. [[1]](diffhunk://#diff-5e11a205dda78e00b710c1850bc7983f80a842cab16f665749cfd88f76d1d068R1-R2) [[2]](diffhunk://#diff-5e11a205dda78e00b710c1850bc7983f80a842cab16f665749cfd88f76d1d068L13-R15) [[3]](diffhunk://#diff-5e11a205dda78e00b710c1850bc7983f80a842cab16f665749cfd88f76d1d068L28-R30)