### PR TITLE
0.4.2

### DIFF
--- a/src/torchlinops/__init__.py
+++ b/src/torchlinops/__init__.py
@@ -1,4 +1,4 @@
 from .alg import *
 from .linops import *
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"

--- a/src/torchlinops/functional/__init__.py
+++ b/src/torchlinops/functional/__init__.py
@@ -8,3 +8,5 @@ from ._interp.grid import grid
 from ._interp.interp import *
 
 from ._index.index import *
+
+from ._nufft import *

--- a/src/torchlinops/functional/_nufft.py
+++ b/src/torchlinops/functional/_nufft.py
@@ -1,0 +1,101 @@
+from torch import Tensor
+from jaxtyping import Float
+from types import SimpleNamespace
+from math import prod
+
+from torchlinops.linops.pad_last import PadLast, pad_to_size, crop_slice_from_pad
+from torchlinops.linops.nufft import NUFFT
+from torchlinops.utils import cfftn, cifftn
+
+from ._interp.interp import interpolate, interpolate_adjoint
+
+__all__ = ["nufft", "nufft_adjoint"]
+
+
+def nufft(
+    x: Tensor,
+    locs: Float[Tensor, "... D"],
+    oversamp: float = 1.25,
+    width: float = 4.0,
+):
+    """Functional interface for NUFFT"""
+
+    grid_size = x.shape[-locs.shape[-1] :]
+    params = init_nufft(grid_size, locs, oversamp, width)
+
+    x = x * params.apodize
+    x = PadLast.fn(params.pad_ns, x)
+    x = cfftn(x, dim=params.dim, norm="ortho")
+    x = interpolate(
+        x,
+        params.locs,
+        width,
+        kernel="kaiser_bessel",
+        kernel_params=dict(beta=params.beta),
+    )
+    x = x / params.scale_factor
+    return x
+
+
+def nufft_adjoint(
+    x: Tensor,
+    locs: Float[Tensor, "... D"],
+    grid_size: tuple[int, ...],
+    oversamp: float = 1.25,
+    width: float = 4.0,
+):
+    """Functional interface for adjoint NUFFT"""
+    params = init_nufft(grid_size, locs, oversamp, width)
+
+    x = x / params.scale_factor
+    x = interpolate_adjoint(
+        x,
+        params.locs,
+        params.padded_size,
+        width,
+        kernel="kaiser_bessel",
+        kernel_params=dict(beta=params.beta),
+    )
+    x = cifftn(x, dim=params.dim, norm="ortho")
+    x = PadLast.adj_fn(params.pad_ns, x)
+    x = x * params.apodize
+    return x
+
+
+def init_nufft(grid_size, locs, oversamp, width):
+    ndim = locs.shape[-1]
+    dim = tuple(range(-ndim, 0))
+    padded_size = tuple(int(s * oversamp) for s in grid_size)
+    locs = NUFFT.prep_locs(locs.clone(), grid_size, padded_size)
+
+    # Apodize weights
+    beta = NUFFT.beta(width, oversamp)
+    apodize = NUFFT.apodize_weights(grid_size, padded_size, oversamp, width, beta)
+
+    # Pad Attrs
+    pad = pad_to_size(grid_size, padded_size)
+    crop_slice = crop_slice_from_pad(pad)
+    pad_ns = SimpleNamespace(
+        im_size=grid_size,
+        pad_im_size=padded_size,
+        D=ndim,
+        pad=pad,
+        crop_slice=crop_slice,
+    )
+
+    # Scale factor
+    scale_factor = width**ndim * (prod(grid_size) / prod(padded_size)) ** 0.5
+    return SimpleNamespace(
+        ndim=ndim,
+        dim=dim,
+        grid_size=grid_size,
+        padded_size=padded_size,
+        locs=locs,
+        beta=beta,
+        apodize=apodize,
+        pad_ns=pad_ns,
+        scale_factor=scale_factor,
+    )
+
+
+# TODO: gridded_nufft, gridded_nufft_adjoint

--- a/src/torchlinops/linops/pad_last.py
+++ b/src/torchlinops/linops/pad_last.py
@@ -67,15 +67,7 @@ class PadLast(NamedLinop):
 
         # Make crop slice that undoes padding
         # Need to reverse crop_slice because padding is reversed
-        self.crop_slice = []
-        for i in range(len(self.pad) // 2):
-            start = self.pad[2 * i]
-            stop = -self.pad[2 * i + 1]
-            if stop == 0:
-                # Don't set stop to 0, set it to the end
-                stop = None
-            self.crop_slice.append(slice(start, stop))
-        self.crop_slice.reverse()
+        self.crop_slice = crop_slice_from_pad(self.pad)
 
     def forward(self, x):
         """Pad the last n dimensions of x"""
@@ -169,3 +161,17 @@ def pad_to_size(grid_size, padded_size):
         pad.append([pad_left, pad_right])
     pad.reverse()
     return sum(pad, start=[])
+
+
+def crop_slice_from_pad(pad):
+    """From a padding list, get the corresponding slicing that undoes it."""
+    crop_slice = []
+    for i in range(len(pad) // 2):
+        start = pad[2 * i]
+        stop = -pad[2 * i + 1]
+        if stop == 0:
+            # Don't set stop to 0, set it to the end
+            stop = None
+        crop_slice.append(slice(start, stop))
+    crop_slice.reverse()
+    return crop_slice

--- a/src/torchlinops/tests/test_toeplitz.py
+++ b/src/torchlinops/tests/test_toeplitz.py
@@ -80,7 +80,7 @@ def test_toeplitz_full(inner_type, nufft_linop, nufft_params, request):
         inner = request.getfixturevalue(inner_type)
     else:
         inner = None
-    kernel, pad, fft = toeplitz_psf(nufft_linop, inner)
+    kernel = toeplitz_psf(nufft_linop, inner)
 
     # Test against sigpy for no inner only
     if inner_type is None:


### PR DESCRIPTION
Includes a fix for NUFFT toeplitz and a functional interface for NUFFT (`F.nufft()` and `F.nufft_adjoint`)

### New Functionalities and Enhancements:
* [`src/torchlinops/functional/_nufft.py`](diffhunk://#diff-62f55c8fa6726538475c7137ddb864a7bc0e39d599ed66dc113e31dbc80235ffR1-R101): Introduced new functions `nufft`, `nufft_adjoint`, and `init_nufft` to provide a functional interface for NUFFT operations.

### Improvements to Existing Methods:

* `src/torchlinops/linops/nufft.py`:
  * Enhanced the `__init__` method with detailed parameter documentation and additional options for Toeplitz embedding. [[1]](diffhunk://#diff-ceda08d3516aac65de0d275621615b0f5f995c2b7bad04a94bedb930b9dc7b41L49-R70) [[2]](diffhunk://#diff-ceda08d3516aac65de0d275621615b0f5f995c2b7bad04a94bedb930b9dc7b41R80-R85)
  * Updated the `normal` method to improve Toeplitz embedding calculations.
  * Simplified the `prep_locs` and `apodize_weights` methods by removing commented-out code. [[1]](diffhunk://#diff-ceda08d3516aac65de0d275621615b0f5f995c2b7bad04a94bedb930b9dc7b41L192) [[2]](diffhunk://#diff-ceda08d3516aac65de0d275621615b0f5f995c2b7bad04a94bedb930b9dc7b41L242-L259)
  * Refactored the `toeplitz_psf` function to streamline the calculation process and remove redundant code. [[1]](diffhunk://#diff-ceda08d3516aac65de0d275621615b0f5f995c2b7bad04a94bedb930b9dc7b41L287-R318) [[2]](diffhunk://#diff-ceda08d3516aac65de0d275621615b0f5f995c2b7bad04a94bedb930b9dc7b41L312-L313) [[3]](diffhunk://#diff-ceda08d3516aac65de0d275621615b0f5f995c2b7bad04a94bedb930b9dc7b41L327) [[4]](diffhunk://#diff-ceda08d3516aac65de0d275621615b0f5f995c2b7bad04a94bedb930b9dc7b41L339-L354) [[5]](diffhunk://#diff-ceda08d3516aac65de0d275621615b0f5f995c2b7bad04a94bedb930b9dc7b41L373-R395) [[6]](diffhunk://#diff-ceda08d3516aac65de0d275621615b0f5f995c2b7bad04a94bedb930b9dc7b41L449)
  * Removed obsolete helper functions.

### Utility Functions:

* `src/torchlinops/linops/pad_last.py`:
  * Added a new utility function `crop_slice_from_pad` to simplify slice creation from padding.
  * Refactored the `__init__` method to use the new utility function.

### Testing Enhancements:

* [`src/torchlinops/tests/test_nufft.py`](diffhunk://#diff-7ca7d3429e0cdc06561d093093b36dcd3cc2be5ab4ddc9605a8e70cc2b47d9f0R13-R14): Added new tests for the functional NUFFT interface to ensure compatibility with existing implementations. [[1]](diffhunk://#diff-7ca7d3429e0cdc06561d093093b36dcd3cc2be5ab4ddc9605a8e70cc2b47d9f0R13-R14) [[2]](diffhunk://#diff-7ca7d3429e0cdc06561d093093b36dcd3cc2be5ab4ddc9605a8e70cc2b47d9f0R96-R115)
* [`src/torchlinops/tests/test_toeplitz.py`](diffhunk://#diff-391d2035d4e1c09177da8b357267e47a8edfb251cb54792e871d8530c45415c7L83-R83): Updated the `test_toeplitz_full` function to align with the new Toeplitz embedding approach.