### PR TITLE
0.4.8 Update

### DIFF
--- a/dev/batch_serialize/log.txt
+++ b/dev/batch_serialize/log.txt
@@ -1,0 +1,112 @@
+Chain(
+    Dense((X, Y) -> (C, X, Y))
+    Dense((C, X, Y) -> (B, C, X, Y))
+)
+Not batched
+Device cuda:0
+====================
+linops.0.weight	(5, 64, 64)		81.92 KiB
+linops.1.weight	(6, 1, 64, 64)		98.30 KiB
+Total: 180.22 KiB
+Concat((X, Y) -> (B, C, X, Y)
+    Concat((X, Y) -> (B, C, X, Y)
+        Chain(
+            Dense((X, Y) -> (C, X, Y))
+            Dense((C, X, Y) -> (B, C, X, Y))
+        )
+        Chain(
+            Dense((X, Y) -> (C, X, Y))
+            Dense((C, X, Y) -> (B, C, X, Y))
+        )
+        Chain(
+            Dense((X, Y) -> (C, X, Y))
+            Dense((C, X, Y) -> (B, C, X, Y))
+        )
+        idim = None, odim = B
+    )
+    Concat((X, Y) -> (B, C, X, Y)
+        Chain(
+            Dense((X, Y) -> (C, X, Y))
+            Dense((C, X, Y) -> (B, C, X, Y))
+        )
+        Chain(
+            Dense((X, Y) -> (C, X, Y))
+            Dense((C, X, Y) -> (B, C, X, Y))
+        )
+        Chain(
+            Dense((X, Y) -> (C, X, Y))
+            Dense((C, X, Y) -> (B, C, X, Y))
+        )
+        idim = None, odim = B
+    )
+    Concat((X, Y) -> (B, C, X, Y)
+        Chain(
+            Dense((X, Y) -> (C, X, Y))
+            Dense((C, X, Y) -> (B, C, X, Y))
+        )
+        Chain(
+            Dense((X, Y) -> (C, X, Y))
+            Dense((C, X, Y) -> (B, C, X, Y))
+        )
+        Chain(
+            Dense((X, Y) -> (C, X, Y))
+            Dense((C, X, Y) -> (B, C, X, Y))
+        )
+        idim = None, odim = B
+    )
+    Concat((X, Y) -> (B, C, X, Y)
+        Chain(
+            Dense((X, Y) -> (C, X, Y))
+            Dense((C, X, Y) -> (B, C, X, Y))
+        )
+        Chain(
+            Dense((X, Y) -> (C, X, Y))
+            Dense((C, X, Y) -> (B, C, X, Y))
+        )
+        Chain(
+            Dense((X, Y) -> (C, X, Y))
+            Dense((C, X, Y) -> (B, C, X, Y))
+        )
+        idim = None, odim = B
+    )
+    Concat((X, Y) -> (B, C, X, Y)
+        Chain(
+            Dense((X, Y) -> (C, X, Y))
+            Dense((C, X, Y) -> (B, C, X, Y))
+        )
+        Chain(
+            Dense((X, Y) -> (C, X, Y))
+            Dense((C, X, Y) -> (B, C, X, Y))
+        )
+        Chain(
+            Dense((X, Y) -> (C, X, Y))
+            Dense((C, X, Y) -> (B, C, X, Y))
+        )
+        idim = None, odim = B
+    )
+    idim = None, odim = C
+)
+Batched
+Device cuda:0
+====================
+linops.0.linops.0.linops.0.weight	(1, 64, 64)		16.38 KiB
+linops.0.linops.0.linops.1.weight	(2, 1, 64, 64)		32.77 KiB
+linops.0.linops.1.linops.1.weight	(2, 1, 64, 64)		32.77 KiB
+linops.0.linops.2.linops.1.weight	(2, 1, 64, 64)		32.77 KiB
+linops.1.linops.0.linops.0.weight	(1, 64, 64)		16.38 KiB
+linops.2.linops.0.linops.0.weight	(1, 64, 64)		16.38 KiB
+linops.3.linops.0.linops.0.weight	(1, 64, 64)		16.38 KiB
+linops.4.linops.0.linops.0.weight	(1, 64, 64)		16.38 KiB
+Total: 180.22 KiB
+Deserialized
+Device cuda:0
+====================
+linops.0.linops.0.linops.0.weight	(1, 64, 64)		16.38 KiB
+linops.0.linops.0.linops.1.weight	(2, 1, 64, 64)		32.77 KiB
+linops.0.linops.1.linops.1.weight	(2, 1, 64, 64)		32.77 KiB
+linops.0.linops.2.linops.1.weight	(2, 1, 64, 64)		32.77 KiB
+linops.1.linops.0.linops.0.weight	(1, 64, 64)		16.38 KiB
+linops.2.linops.0.linops.0.weight	(1, 64, 64)		16.38 KiB
+linops.3.linops.0.linops.0.weight	(1, 64, 64)		16.38 KiB
+linops.4.linops.0.linops.0.weight	(1, 64, 64)		16.38 KiB
+Total: 180.22 KiB

--- a/dev/batch_serialize/serialize_batched_linop.py
+++ b/dev/batch_serialize/serialize_batched_linop.py
@@ -16,15 +16,15 @@ def main():
     B, C, X, Y = 6, 5, 64, 64
     input_ = torch.randn(X, Y)
     S = Dense(torch.randn(C, X, Y), Dim("CXY"), ishape=Dim("XY"), oshape=Dim("CXY"))
-    F = Dense(torch.randn(B, C), Dim("BC"), ishape=Dim("CXY"), oshape=Dim("BXY"))
-    D = Diagonal.from_weight(torch.randn(B), Dim("B"), ioshape=Dim("B()()"))
+    F = Dense(torch.randn(B, 1, X, Y), Dim("B"), ishape=Dim("CXY"), oshape=Dim("BCXY"))
 
     # Make linop
-    A = D @ F @ S
+    A = F @ S
     A.to(device)
     print("Not batched")
     MemReporter().report(A)
-    A = create_batched_linop(A, BatchSpec({"C": 1, "B": 2}))
+    A = create_batched_linop(A, [BatchSpec({"C": 1}), BatchSpec({"B": 2})])
+    print(A)
 
     # Print memory usage
     print("Batched")

--- a/dev/batch_serialize/serialize_batched_linop.py
+++ b/dev/batch_serialize/serialize_batched_linop.py
@@ -1,12 +1,9 @@
-import torch
-from torchlinops import (
-    BatchSpec,
-    Dense,
-    Diagonal,
-    create_batched_linop,
-    Dim,
-)
+from collections import defaultdict
+from copy import deepcopy
 
+import torch
+import torch.nn as nn
+from torchlinops import BatchSpec, Dense, Diagonal, Dim, create_batched_linop
 from torchlinops.utils import MemReporter
 
 
@@ -22,24 +19,133 @@ def main():
     A = F @ S
     A.to(device)
     print(A)
-    print("Not batched")
+    print("Not batched (GPU)")
     MemReporter().report(A)
     A = create_batched_linop(A, [BatchSpec({"C": 1}), BatchSpec({"B": 2})])
     print(A)
 
     # Print memory usage
-    print("Batched")
+    print("Batched (GPU)")
     MemReporter().report(A)
 
     # Serialize
     torch.save(A, "A.pt")
-
     A2 = torch.load("A.pt", weights_only=False)
 
     # Print memory usage
-    print("Deserialized")
+    print("Deserialized (GPU -> GPU)")
     MemReporter().report(A2)
+
+    # CPU
+    # Memory drastically expands again...
+    A3 = deepcopy(A).to("cpu")
+    print("CPU")
+    MemReporter().report(A3)
+
+    # Preserve references
+    A4 = move_module_preserve_sharing(A, "cpu")
+    print("CPU Attempt #2")
+    MemReporter().report(A4)
+
+
+def move_module_preserve_sharing(module: nn.Module, device):
+    # Map from original storage ID to list of (tensor, name)
+    storage_tensors = defaultdict(list)
+
+    def collect(m):
+        for name, t in list(m.named_parameters(recurse=False)) + list(
+            m.named_buffers(recurse=False)
+        ):
+            if t is None:
+                continue
+            key = t.untyped_storage()._cdata
+            storage_tensors[key].append(t)
+        for child in m.children():
+            collect(child)
+
+    collect(module)
+
+    # Move unique storage blocks
+    storage_map = {}
+    for key, tensors in storage_tensors.items():
+        # Find max offset + size for any tensor sharing this storage
+        max_offset = 0
+        dtype = None
+        device_orig = None
+        for t in tensors:
+            size_bytes = t.element_size() * max_storage_size(t)
+            offset_bytes = t.storage_offset() * t.element_size()
+            max_offset = max(max_offset, offset_bytes + size_bytes)
+            dtype = t.dtype
+            device_orig = t.device
+
+        # Create a flat tensor that spans the full required storage
+        base_tensor = torch.empty(
+            (max_offset // torch.tensor([], dtype=dtype).element_size(),),
+            dtype=dtype,
+            device=device_orig,
+        )
+        storage_map[key] = base_tensor.to(device)
+
+    # Replace parameters/buffers
+    def remap(m):
+        for name, t in m._parameters.items():
+            if t is not None:
+                new_t = as_view_on_moved(t, storage_map)
+                m._parameters[name] = nn.Parameter(new_t, requires_grad=t.requires_grad)
+        for name, t in m._buffers.items():
+            if t is not None:
+                m._buffers[name] = as_view_on_moved(t, storage_map)
+        for child in m.children():
+            remap(child)
+
+    remap(module)
+    return module
+
+
+def max_storage_size(tensor):
+    """Compute the number of elements spanned by a strided tensor."""
+    if tensor.numel() == 0:
+        return 0
+    size = 0
+    for i, (dim, stride) in enumerate(zip(tensor.size(), tensor.stride())):
+        size += (dim - 1) * stride
+    return size + 1
+
+
+def as_view_on_moved(tensor, storage_map):
+    storage = tensor.untyped_storage()
+    key = storage._cdata
+    base = storage_map[key]
+    return base.as_strided(tensor.size(), tensor.stride(), tensor.storage_offset())
+
+
+class TestModule(nn.Module):
+    def __init__(self):
+        super().__init__()
+        base = torch.empty(4 * 64 * 64)
+        self.shared_view = nn.Parameter(
+            base.as_strided((2, 1, 64, 64), (4096, 4096, 64, 1), 8192)
+        )
+        self.same_view = nn.Parameter(self.shared_view)
+        self.empty = nn.Parameter(torch.tensor([], dtype=torch.float32))
+        self.zero_shape = nn.Parameter(torch.empty((0, 3, 224)))
+        self.noncontig = nn.Parameter(
+            torch.arange(12).view(3, 4).t(), requires_grad=False
+        )  # transposed (non-contig)
 
 
 if __name__ == "__main__":
     main()
+
+    model = TestModule()
+    model_cuda = move_module_preserve_sharing(model, torch.device("cuda"))
+
+    # Assertions
+    assert (
+        model_cuda.shared_view.untyped_storage()._cdata
+        == model_cuda.same_view.untyped_storage()._cdata
+    )
+    assert model_cuda.empty.numel() == 0 and model_cuda.empty.device.type == "cuda"
+    assert model_cuda.zero_shape.shape == (0, 3, 224)
+    assert not model_cuda.noncontig.is_contiguous()

--- a/dev/batch_serialize/serialize_batched_linop.py
+++ b/dev/batch_serialize/serialize_batched_linop.py
@@ -21,6 +21,7 @@ def main():
     # Make linop
     A = F @ S
     A.to(device)
+    print(A)
     print("Not batched")
     MemReporter().report(A)
     A = create_batched_linop(A, [BatchSpec({"C": 1}), BatchSpec({"B": 2})])
@@ -38,8 +39,6 @@ def main():
     # Print memory usage
     print("Deserialized")
     MemReporter().report(A2)
-
-    # Everything seems ok?
 
 
 if __name__ == "__main__":

--- a/dev/batch_serialize/serialize_batched_linop.py
+++ b/dev/batch_serialize/serialize_batched_linop.py
@@ -36,116 +36,50 @@ def main():
     print("Deserialized (GPU -> GPU)")
     MemReporter().report(A2)
 
+    # Deepcopy
+    # Memory expands?
+    A_copy = deepcopy(A)
+    print("A_copy")
+    MemReporter().report(A_copy)
+    breakpoint()
+    print("A_copy is different: ")
+    breakpoint()
+
     # CPU
     # Memory drastically expands again...
-    A3 = deepcopy(A).to("cpu")
+    A_copy = deepcopy(A)
+    MemReporter().report(A_copy)
+    A3 = A_copy.to("cpu")
     print("CPU")
     MemReporter().report(A3)
 
     # Preserve references
-    A4 = move_module_preserve_sharing(A, "cpu")
+    A4 = A.to("cpu")
     print("CPU Attempt #2")
     MemReporter().report(A4)
 
 
-def move_module_preserve_sharing(module: nn.Module, device):
-    # Map from original storage ID to list of (tensor, name)
-    storage_tensors = defaultdict(list)
+def test_deepcopy():
+    """Requires CUDA"""
+    device = torch.device("cuda:0")
+    B, C, X, Y = 6, 5, 64, 64
+    input_ = torch.randn(X, Y)
+    S = Dense(torch.randn(C, X, Y), Dim("CXY"), ishape=Dim("XY"), oshape=Dim("CXY"))
+    F = Dense(torch.randn(B, 1, X, Y), Dim("B"), ishape=Dim("CXY"), oshape=Dim("BCXY"))
 
-    def collect(m):
-        for name, t in list(m.named_parameters(recurse=False)) + list(
-            m.named_buffers(recurse=False)
-        ):
-            if t is None:
-                continue
-            key = t.untyped_storage()._cdata
-            storage_tensors[key].append(t)
-        for child in m.children():
-            collect(child)
+    # Make linop
+    A = F @ S
+    A.to(device)
+    A = create_batched_linop(A, [BatchSpec({"C": 1}), BatchSpec({"B": 2})])
 
-    collect(module)
+    # deepcopy
+    # Memory drastically expands again...
+    A_copy = deepcopy(A)
+    MemReporter().report(A_copy)
 
-    # Move unique storage blocks
-    storage_map = {}
-    for key, tensors in storage_tensors.items():
-        # Find max offset + size for any tensor sharing this storage
-        max_offset = 0
-        dtype = None
-        device_orig = None
-        for t in tensors:
-            size_bytes = t.element_size() * max_storage_size(t)
-            offset_bytes = t.storage_offset() * t.element_size()
-            max_offset = max(max_offset, offset_bytes + size_bytes)
-            dtype = t.dtype
-            device_orig = t.device
-
-        # Create a flat tensor that spans the full required storage
-        base_tensor = torch.empty(
-            (max_offset // torch.tensor([], dtype=dtype).element_size(),),
-            dtype=dtype,
-            device=device_orig,
-        )
-        storage_map[key] = base_tensor.to(device)
-
-    # Replace parameters/buffers
-    def remap(m):
-        for name, t in m._parameters.items():
-            if t is not None:
-                new_t = as_view_on_moved(t, storage_map)
-                m._parameters[name] = nn.Parameter(new_t, requires_grad=t.requires_grad)
-        for name, t in m._buffers.items():
-            if t is not None:
-                m._buffers[name] = as_view_on_moved(t, storage_map)
-        for child in m.children():
-            remap(child)
-
-    remap(module)
-    return module
-
-
-def max_storage_size(tensor):
-    """Compute the number of elements spanned by a strided tensor."""
-    if tensor.numel() == 0:
-        return 0
-    size = 0
-    for i, (dim, stride) in enumerate(zip(tensor.size(), tensor.stride())):
-        size += (dim - 1) * stride
-    return size + 1
-
-
-def as_view_on_moved(tensor, storage_map):
-    storage = tensor.untyped_storage()
-    key = storage._cdata
-    base = storage_map[key]
-    return base.as_strided(tensor.size(), tensor.stride(), tensor.storage_offset())
-
-
-class TestModule(nn.Module):
-    def __init__(self):
-        super().__init__()
-        base = torch.empty(4 * 64 * 64)
-        self.shared_view = nn.Parameter(
-            base.as_strided((2, 1, 64, 64), (4096, 4096, 64, 1), 8192)
-        )
-        self.same_view = nn.Parameter(self.shared_view)
-        self.empty = nn.Parameter(torch.tensor([], dtype=torch.float32))
-        self.zero_shape = nn.Parameter(torch.empty((0, 3, 224)))
-        self.noncontig = nn.Parameter(
-            torch.arange(12).view(3, 4).t(), requires_grad=False
-        )  # transposed (non-contig)
+    assert id(A[0][0][0].weight) != id(A_copy[0][0][0].weight)
 
 
 if __name__ == "__main__":
     main()
-
-    model = TestModule()
-    model_cuda = move_module_preserve_sharing(model, torch.device("cuda"))
-
-    # Assertions
-    assert (
-        model_cuda.shared_view.untyped_storage()._cdata
-        == model_cuda.same_view.untyped_storage()._cdata
-    )
-    assert model_cuda.empty.numel() == 0 and model_cuda.empty.device.type == "cuda"
-    assert model_cuda.zero_shape.shape == (0, 3, 224)
-    assert not model_cuda.noncontig.is_contiguous()
+    test_deepcopy()

--- a/dev/batch_serialize/serialize_batched_linop.py
+++ b/dev/batch_serialize/serialize_batched_linop.py
@@ -1,0 +1,46 @@
+import torch
+from torchlinops import (
+    BatchSpec,
+    Dense,
+    Diagonal,
+    create_batched_linop,
+    Dim,
+)
+
+from torchlinops.utils import MemReporter
+
+
+def main():
+    """Requires CUDA"""
+    device = torch.device("cuda:0")
+    B, C, X, Y = 6, 5, 64, 64
+    input_ = torch.randn(X, Y)
+    S = Dense(torch.randn(C, X, Y), Dim("CXY"), ishape=Dim("XY"), oshape=Dim("CXY"))
+    F = Dense(torch.randn(B, C), Dim("BC"), ishape=Dim("CXY"), oshape=Dim("BXY"))
+    D = Diagonal.from_weight(torch.randn(B), Dim("B"), ioshape=Dim("B()()"))
+
+    # Make linop
+    A = D @ F @ S
+    A.to(device)
+    print("Not batched")
+    MemReporter().report(A)
+    A = create_batched_linop(A, BatchSpec({"C": 1, "B": 2}))
+
+    # Print memory usage
+    print("Batched")
+    MemReporter().report(A)
+
+    # Serialize
+    torch.save(A, "A.pt")
+
+    A2 = torch.load("A.pt", weights_only=False)
+
+    # Print memory usage
+    print("Deserialized")
+    MemReporter().report(A2)
+
+    # Everything seems ok?
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "einops>=0.8.0",
     "tqdm>=4.67.1",
     "scipy>=1.15.2",
+    "multimethod>=2.0",
 ]
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/torchlinops/linops/namedlinop.py
+++ b/src/torchlinops/linops/namedlinop.py
@@ -1,6 +1,7 @@
 import logging
 import traceback
 import types
+from collections import defaultdict
 from collections.abc import Mapping
 from copy import copy, deepcopy
 from functools import partial
@@ -11,7 +12,7 @@ import torch.nn as nn
 import torchlinops
 import torchlinops.config as config
 from multimethod import multimethod
-from torchlinops.utils import INDENT
+from torchlinops.utils import INDENT, memory_aware_to, memory_aware_deepcopy
 
 from .nameddim import NS
 from .nameddim import NamedDimension as ND
@@ -339,6 +340,9 @@ class NamedLinop(nn.Module):
     def oshape(self, val):
         self._shape.oshape = val
 
+    def to(self, device):
+        return memory_aware_to(self, device)
+
     def __copy__(self):
         """
         copying a linop:
@@ -362,6 +366,9 @@ class NamedLinop(nn.Module):
         # Create new shape
         new._shape = deepcopy(self._shape)
         return new
+
+    def __deepcopy__(self, _):
+        return memory_aware_deepcopy(self)
 
 
 class NormalFunctionLookup:

--- a/src/torchlinops/linops/split.py
+++ b/src/torchlinops/linops/split.py
@@ -130,7 +130,7 @@ def split_linop(
     for tile in tiles:
         idx = _tile_get_idx(tile, batch_dims)
         linop_tile = split_linop_with_tile(linop, tile)
-        linop_flat = linop.flatten()
+        linop_flat = linop_tile.flatten()
         first_linop, last_linop = linop_flat[0], linop_flat[-1]
         if device_matrix is not None:
             device = device_matrix[idx]

--- a/src/torchlinops/linops/split.py
+++ b/src/torchlinops/linops/split.py
@@ -129,7 +129,9 @@ def split_linop(
 
     for tile in tiles:
         idx = _tile_get_idx(tile, batch_dims)
-        ibatches, obatches, linop_tile = split_linop_with_tile(linop, tile)
+        linop_tile = split_linop_with_tile(linop, tile)
+        linop_flat = linop.flatten()
+        first_linop, last_linop = linop_flat[0], linop_flat[-1]
         if device_matrix is not None:
             device = device_matrix[idx]
             linop_tile = (
@@ -138,8 +140,12 @@ def split_linop(
                 @ ToDevice(base_device, device, linop_tile.ishape)
             )
         linops[idx] = linop_tile
-        input_batches[idx] = ibatches[0]  # input batch of first linop
-        output_batches[idx] = obatches[-1]  # output batch of last linop
+        input_batches[idx] = [
+            tile.get(dim, DEFAULT_BATCH)[1] for dim in first_linop.ishape
+        ]
+        output_batches[idx] = [
+            tile.get(dim, DEFAULT_BATCH)[1] for dim in last_linop.oshape
+        ]
     return linops, input_batches, output_batches
 
 
@@ -188,20 +194,14 @@ def fuzzy_broadcast_to(arr: np.ndarray, target_shape):
 
 def split_linop_with_tile(linop: NamedLinop, tile: Tile):
     """Split a linop according to batch specified in tile"""
-    ibatches = [_tile_shape2batch(tile, op.ishape) for op in linop.flatten()]
-    obatches = [_tile_shape2batch(tile, op.oshape) for op in linop.flatten()]
-    linop_tile = linop.split(linop, *ibatches, *obatches)
-    return ibatches, obatches, linop_tile
+    slice_map = {key: value[1] for key, value in tile.items()}
+    linop_tile = linop.split(linop, slice_map)
+    return linop_tile
 
 
 def _tile_get_idx(tile: Tile, batch_dims) -> tuple[int]:
     """Get all indices from the tile"""
     return tuple(tile.get(dim, DEFAULT_BATCH)[0] for dim in batch_dims)
-
-
-def _tile_shape2batch(tile: Tile, shape: tuple[ND | str, ...]) -> list[slice]:
-    """Get all batches from the tile in a specific order according to the provided shapes"""
-    return [tile.get(dim, DEFAULT_BATCH)[1] for dim in shape]
 
 
 def make_batch_iterators(

--- a/src/torchlinops/linops/split.py
+++ b/src/torchlinops/linops/split.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from functools import partial
 from math import ceil
 from typing import Literal, Optional
+from warnings import warn
 
 import numpy as np
 import torch
@@ -28,13 +29,19 @@ class BatchSpec:
     device_matrix: Optional[np.ndarray | list] = None
     base_device: Optional[torch.device] = "cpu"
 
+    def __post_init__(self):
+        if not isinstance(self.batch_sizes, dict):
+            warn(
+                f"Got {self.batch_sizes} of type {type(self.batch_sizes).__name__} for batch_sizes instead of dict."
+            )
+
 
 def create_batched_linop(linop, batch_specs: BatchSpec | list[BatchSpec]):
     """
     Examples
     --------
     >>> from torchlinops import Dense
-    >>> congpu_batchspec = BatchSpec({"B": 2})
+    >>> non_gpu_batchspec = BatchSpec({"B": 2})
     >>> gpu_batchspec = BatchSpec({"C": 1}, device_matrix=[torch.device("cuda:0"), "cpu"])
 
     """

--- a/src/torchlinops/linops/stack.py
+++ b/src/torchlinops/linops/stack.py
@@ -1,20 +1,18 @@
-from typing import Optional
-from jaxtyping import Integer
-from torch import Tensor
-
+from collections.abc import Mapping
 from copy import copy
+from typing import Optional
 
 import torch
 import torch.nn as nn
+from jaxtyping import Integer
+from torch import Tensor
+from torchlinops.functional import slice2range
+from torchlinops.utils import INDENT, default_to
 
-from .namedlinop import NamedLinop
 from .add import Add
 from .identity import Zero
-from .nameddim import NS, isequal, ELLIPSES, NDorStr, ND
-
-from torchlinops.functional import slice2range
-
-from torchlinops.utils import default_to, INDENT
+from .nameddim import ELLIPSES, ND, NS, NDorStr, isequal
+from .namedlinop import NamedLinop
 
 __all__ = ["Stack"]
 
@@ -169,14 +167,19 @@ class Stack(NamedLinop):
         output_linops = []
         # Remove stack dims from slice batch
         if self.idim_idx is not None:
+            ibatch = ibatch.copy()
             ibatch.pop(self.idim_idx)
         if self.odim_idx is not None:
+            obatch = obatch.copy()
             obatch.pop(self.odim_idx)
 
         # Slice each sub-linop
         for i in linop_idxs:
             linop = self.linops[i]
-            output_linops.append(linop.split_forward(ibatch, obatch))
+            islices = {dim: slc for dim, slc in zip(linop.ishape, ibatch)}
+            oslices = {dim: slc for dim, slc in zip(linop.oshape, obatch)}
+            slices = strict_update(islices, oslices)
+            output_linops.append(linop.split(linop, slices))
         return type(self)(
             *output_linops,
             idim_and_idx=(self.idim, self.idim_idx),
@@ -319,3 +322,27 @@ class Stack(NamedLinop):
             output += INDENT.indent(f"idim = {self.idim}, odim = {self.odim}\n")
         output += INDENT.indent(")")
         return output
+
+def strict_update(d1: Mapping, d2: Mapping) -> Mapping:
+    """Strictly updates one dictionary with values from the other.
+
+    Parameters
+    ----------
+    d1, d2 : Mappings
+        The mappings to combine.
+
+    Returns
+    -------
+    Mapping
+        The combined mapping.
+
+    Raises
+    ------
+    ValueError
+        If there are conflicting keys.
+    """
+    for k, v in d2.items():
+        if k in d1 and d1[k] != v:
+            raise ValueError(f"Conflict at key '{k}': {d1[k]} != {v}")
+    d1.update(d2)
+    return d1

--- a/src/torchlinops/linops/stack.py
+++ b/src/torchlinops/linops/stack.py
@@ -7,7 +7,7 @@ import torch.nn as nn
 from jaxtyping import Integer
 from torch import Tensor
 from torchlinops.functional import slice2range
-from torchlinops.utils import INDENT, default_to
+from torchlinops.utils import INDENT
 
 from .add import Add
 from .identity import Zero

--- a/src/torchlinops/tests/test_base.py
+++ b/src/torchlinops/tests/test_base.py
@@ -61,3 +61,8 @@ class BaseNamedLinopTests(ABC):
         A, x, y = linop_input_output
         self.test_adjoint((A.N, x, x))
         self.test_normal((A.N, x, x))
+
+    def test_split(self, linop_input_output):
+        A, x, y = linop_input_output
+        for dim in set(A.ishape + A.oshape):
+            ...

--- a/src/torchlinops/utils/_device.py
+++ b/src/torchlinops/utils/_device.py
@@ -1,6 +1,13 @@
-import torch
+import gc
+from collections import defaultdict
+from typing import Literal, Optional
+from warnings import warn
 
-__all__ = ["get_device", "device_ordinal", "same_storage"]
+import torch
+import torch.nn as nn
+from torch import Tensor
+
+__all__ = ["get_device", "device_ordinal", "same_storage", "MemReporter"]
 
 
 def get_device(device_idx: int = -1):
@@ -16,3 +23,150 @@ def same_storage(x, y):
     x_ptrs = set(e.data_ptr() for e in x.view(-1))
     y_ptrs = set(e.data_ptr() for e in y.view(-1))
     return (x_ptrs <= y_ptrs) or (y_ptrs <= x_ptrs)
+
+
+class MemReporter:
+    """A utility class for reporting memory usage of PyTorch tensors by device.
+
+    Features:
+        - Tracks tensors in Python scope (excluding C++-managed buffers)
+        - Reports memory in GB (base 1024) or GiB (base 1000) format
+        - Identifies root tensors to avoid double-counting overlapping memory
+        - Supports module-specific analysis or global tensor tracking
+
+    Parameters
+    ----------
+    format_mode : Literal["GB", "GiB"]
+        Memory unit format (GB=base1024, GiB=base1000)
+
+    Attributes
+    ----------
+    tensors : dict
+        Name-to-tensor mapping for all collected tensors
+    device_map : defaultdict
+        Maps devices to tensor names
+
+    Examples
+    --------
+    >>> reporter = MemReporter(format_mode="GiB")
+    >>> reporter.report()  # Analyze all tracked tensors
+    >>> reporter.report(module=my_model)  # Analyze tensors in a specific module
+
+    Notes
+    -----
+    - Does not track:
+        * Tensors allocated in C++ (e.g. backward pass buffers)
+        * Gradient tensors (.grad attributes)
+    - Non-contiguous tensors may have inefficient pointer calculations
+    """
+
+    def __init__(self, format_mode: Literal["GB", "GiB"] = "GiB"):
+        self.format_mode = format_mode
+        self.tensors = {}
+        self.device_map = defaultdict(list)
+
+    @staticmethod
+    def _sizeof(tensor):
+        return tensor.element_size() * tensor.nelement()
+
+    @staticmethod
+    def _format_size(size_B, mode: Literal["GB", "GiB"] = "GB"):
+        if mode == "GB":
+            base = 1024
+            prefix = ["K", "M", "G"]
+        elif mode == "GiB":
+            base = 1000
+            prefix = ["Ki", "Mi", "Gi"]
+        if size_B < base:
+            return f"{size_B}", "B"
+        elif size_B < base**2:
+            return f"{size_B / base:.2f}", f"{prefix[0]}B"
+        elif size_B < base**3:
+            return f"{size_B / (base**2):.2f}", f"{prefix[1]}B"
+        else:
+            return f"{size_B / (base**3):.2f}", f"{prefix[2]}B"
+
+    def _collect_tensors(self, module: Optional[nn.Module] = None):
+        """Collect all tensor objects tracked by python
+
+        NOTICE:
+            - the buffers for backward which is implemented in C++ are
+            not tracked by python's reference counting.
+            - the gradients(.grad) of Parameters is not collected, and
+            I don't know why.
+        """
+        gc.collect()
+        if module is None:
+            objects = gc.get_objects()
+            n = len(self.tensors)  # Track number of tensors
+            for obj in objects:
+                if isinstance(obj, Tensor):
+                    name = f"Tensor{n}"
+                    self.tensors[name] = obj
+                    self.device_map[obj.device].append(name)
+                    n += 1
+        else:
+            for name, t in module.named_parameters():
+                self.tensors[name] = t
+                self.device_map[t.device].append(name)
+        # print(f"{len(self.tensors)} tensor(s) collected")
+
+    def _get_root_tensors(self, device, names):
+        ptrs = {}
+        for name, t in self.tensors.items():
+            if device == t.device and name in names:
+                # Get range of start and end pointers
+                if not t.is_contiguous():
+                    warn(f"Non-contiguous tensor {name} cannot be indexed efficiently")
+                # (start, end)
+                # ptrs[name] = (t.view(-1)[0].data_ptr(), t.view(-1)[-1].data_ptr())
+                ptrs[name] = (
+                    t.data_ptr(),
+                    t.data_ptr() + t.nelement() * t.element_size() - 1,
+                )
+        # print(f"Collected {len(self.ptrs)} tensors")
+        # Create a dependency graph of inclusion
+        roots = []
+        for name, this_ptrs in ptrs.items():
+            counted = False
+            new_roots = []
+            for root in roots:
+                root_ptrs = ptrs[root]
+                if this_ptrs[0] >= root_ptrs[0] and this_ptrs[1] <= root_ptrs[1]:
+                    # root supercedes this
+                    new_roots.append(root)
+                    counted = True
+                elif this_ptrs[0] <= root_ptrs[0] and this_ptrs[1] >= root_ptrs[1]:
+                    # this supercedes root
+                    new_roots.append(name)
+                    counted = True
+                else:
+                    # Other options that we didn't deal with...
+                    # Independent
+                    new_roots.append(root)
+                    pass
+
+            if not counted:
+                new_roots.append(name)
+            else:
+                pass
+            roots = new_roots
+        return roots
+
+    def report(self, module: Optional[nn.Module] = None):
+        self._collect_tensors(module)
+        for dev, names in self.device_map.items():
+            total_size = 0
+            roots = self._get_root_tensors(dev, names)
+            print(f"Device {dev}")
+            print("=" * 20)
+            for name in names:
+                if name in roots:
+                    tensor = self.tensors[name]
+                    shape = tuple(tensor.shape)
+                    tsize = self._sizeof(tensor)
+                    size, NB = self._format_size(tsize, self.format_mode)
+                    print(f"{name}\t{shape}\t\t{size} {NB}")
+                    total_size += tsize
+            size, NB = self._format_size(total_size, self.format_mode)
+            print(f"Total: {size} {NB}")

--- a/src/torchlinops/utils/_device.py
+++ b/src/torchlinops/utils/_device.py
@@ -199,10 +199,10 @@ class MemReporter:
     @staticmethod
     def _format_size(size_B, mode: Literal["GB", "GiB"] = "GB"):
         if mode == "GB":
-            base = 1024
+            base = 1000
             prefix = ["K", "M", "G"]
         elif mode == "GiB":
-            base = 1000
+            base = 1024
             prefix = ["Ki", "Mi", "Gi"]
         if size_B < base:
             return f"{size_B}", "B"

--- a/uv.lock
+++ b/uv.lock
@@ -1677,6 +1677,15 @@ wheels = [
 ]
 
 [[package]]
+name = "multimethod"
+version = "2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/55/14/34e8c84ba4f1ab1186dc07426e0e84be71d3336cc57e8d076ee14331d50e/multimethod-2.0.tar.gz", hash = "sha256:c628b6d2e7d61fbe58484dd884d990901e8314faf58af062e72b65e3423cb109", size = 16065, upload-time = "2024-12-27T02:09:34.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/42/a285fc4b89b3a249538954779cd4082a85bf35dc7d0a9c93e48e146e3dc7/multimethod-2.0-py3-none-any.whl", hash = "sha256:45aa231dc9dbb7f980c0f2ad8179e2c2b72a8cd5c7d7534337be66dde29d35be", size = 9836, upload-time = "2024-12-27T02:09:31.671Z" },
+]
+
+[[package]]
 name = "myst-nb"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3267,6 +3276,7 @@ source = { editable = "." }
 dependencies = [
     { name = "einops" },
     { name = "jaxtyping" },
+    { name = "multimethod" },
     { name = "scipy" },
     { name = "setuptools" },
     { name = "torch", version = "2.2.2", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'" },
@@ -3335,6 +3345,7 @@ sigpy = [
 requires-dist = [
     { name = "einops", specifier = ">=0.8.0" },
     { name = "jaxtyping", specifier = ">=0.2.36" },
+    { name = "multimethod", specifier = ">=2.0" },
     { name = "scipy", specifier = ">=1.15.2" },
     { name = "setuptools", specifier = ">=75.6.0" },
     { name = "torch", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'", specifier = ">=2.5.1" },


### PR DESCRIPTION
This pull request introduces enhancements to the serialization and batching of linear operators (`linops`) in the `torchlinops` library. Key changes include the addition of multimethod support for splitting operators, memory-efficient serialization and deserialization, and improvements to batch specifications and handling. These changes aim to optimize performance, improve code maintainability, and add flexibility for handling complex operations.

## New Features
### Multiple dispatch for `split()` and `adj_split()`
* [`src/torchlinops/linops/chain.py`](diffhunk://#diff-646f5180b0140eee5e56b77e166ef401d3348dae56955416df074d42781277f1L124-R166): Replaced static methods `split` and `adj_split` with multimethods to handle slices and mappings for splitting operators. This adds flexibility for input/output batch specifications.
* [`src/torchlinops/linops/namedlinop.py`](diffhunk://#diff-b7c19c165b02e4d1d6f75220b1bce2702805ee6f2312cd84bd8853d03e45cea4L206-R210): Introduced multimethods for splitting and adjoint splitting of named linear operators, enabling support for mapping-based batch slicing. [[1]](diffhunk://#diff-b7c19c165b02e4d1d6f75220b1bce2702805ee6f2312cd84bd8853d03e45cea4L206-R210) [[2]](diffhunk://#diff-b7c19c165b02e4d1d6f75220b1bce2702805ee6f2312cd84bd8853d03e45cea4L216-R244)
* [`src/torchlinops/linops/split.py`](diffhunk://#diff-262b0bb072279bfb2d28bc1ee98de52a0389237226393e4c9aa58589d482c516R32-R44): Added validation for batch specifications in `BatchSpec` and improved handling of tiles and slices for splitting linear operators. [[1]](diffhunk://#diff-262b0bb072279bfb2d28bc1ee98de52a0389237226393e4c9aa58589d482c516R32-R44) [[2]](diffhunk://#diff-262b0bb072279bfb2d28bc1ee98de52a0389237226393e4c9aa58589d482c516L125-R134) [[3]](diffhunk://#diff-262b0bb072279bfb2d28bc1ee98de52a0389237226393e4c9aa58589d482c516L184-L199)

### Memory-efficient `to()` and `deepcopy()` for `NamedLinop`s
* [`src/torchlinops/utils/_device.py`](diffhunk://#diff-4d81fcfd314f0303ad1a698addf159ec4a80c9f808fcd7f9915aa567087d816cR23) Memory-aware `to()` that prevents unnecessary memory overflows.
* [`src/torchlinops/utils/_device.py`](diffhunk://#diff-4d81fcfd314f0303ad1a698addf159ec4a80c9f808fcd7f9915aa567087d816cR42) Memory-aware `deepcopy()` that prevents unnecessary memory overflows.

## Misc Fixes and improvements
### Serialization and batching improvements:
* [`dev/batch_serialize/serialize_batched_linop.py`](diffhunk://#diff-41926eb2e23d8bdbb5e80f7896ed183f473e27cef8e53714f421eaa5b90df7f5R1-R85): Added a script to demonstrate serialization, deserialization, and memory reporting of batched linear operators, including support for deep copying and device transfers.

### Utility and testing updates:
* [`src/torchlinops/linops/stack.py`](diffhunk://#diff-e5b174a864e9b95990747c01427487e6ec533e1e14f99f1fae45e99616c86cd5R170-R182): Fixed a bug making it hard to split linops combined via `Stack` [[1]](diffhunk://#diff-e5b174a864e9b95990747c01427487e6ec533e1e14f99f1fae45e99616c86cd5R170-R182) [[2]](diffhunk://#diff-e5b174a864e9b95990747c01427487e6ec533e1e14f99f1fae45e99616c86cd5R325-R348)

### Dependency updates:
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R25): Added `multimethod` dependency to enable multimethod functionality for operator splitting.


Closes #60, #61 