### PR TITLE
Multi-GPU batching, Memory management

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
       - develop
+  push:
+    branches:
+      - main
+      - develop
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -13,6 +17,10 @@ concurrency:
 jobs:
   python-install-lint-test:
     name: ${{ matrix.os }} - Python ${{ matrix.python-version }}
+    if: >
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'push' &&
+       (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop'))
     runs-on: ${{ matrix.os  }}
     timeout-minutes: 15
     defaults:

--- a/dev/cuda_streams/profile_streams_v2.py
+++ b/dev/cuda_streams/profile_streams_v2.py
@@ -1,0 +1,48 @@
+import time
+
+import torch
+from torch.cuda import Stream
+from torch.profiler import ProfilerActivity, profile, record_function
+
+from torchlinops import BatchSpec, Dense, Dim, create_batched_linop
+
+
+def main():
+    device_idxs = [0, 1]
+    devices = [torch.device(f"cuda:{idx}") for idx in device_idxs]
+    # device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    B, M, N = 6, 100000, 10000
+    # Set up
+    weight = torch.randn(B, M, N, device=devices[0])
+    As = {}
+    for device in devices:
+        As[device] = Dense(weight, Dim("BMN"), ishape=Dim("BN"), oshape=Dim("BM")).to(
+            device
+        )
+
+    # A.to(devices[0])
+    # A = create_batched_linop(
+    #     A, BatchSpec({"B": 3}, device_matrix=devices, base_device=devices[0])
+    # )
+
+    # Prepare streams
+    streams = {device: Stream(device) for device in devices}
+
+    x = torch.randn(B, N, device=devices[0])
+    with profile(
+        activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA],
+        on_trace_ready=lambda p: p.export_chrome_trace("./trace.json"),
+    ) as prof:
+        for i in range(10):
+            for device in devices:
+                stream = streams[device]
+                with torch.cuda.stream(stream):
+                    x_dev = x.to(device, non_blocking=True)
+                    y = As[device](x_dev)
+            time.sleep(0.2)
+        for device in devices:
+            torch.cuda.synchronize(device)
+
+
+if __name__ == "__main__":
+    main()

--- a/dev/cuda_streams/profile_streams_v3.py
+++ b/dev/cuda_streams/profile_streams_v3.py
@@ -1,0 +1,108 @@
+import time
+
+import torch
+from torch.cuda import Stream
+from torch.profiler import ProfilerActivity, profile, record_function
+
+from torchlinops import BatchSpec, Dense, Dim, ToDevice, create_batched_linop
+
+
+def main(todevice: bool = False):
+    device_idxs = [0, 1]
+    devices = [torch.device(f"cuda:{idx}") for idx in device_idxs]
+    streams = {device: Stream(device) for device in devices}
+    # device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    B, M, N = 6, 100000, 10000
+    # Set up
+    weight = torch.randn(B, M, N, device=devices[0])
+    As = {}
+    base_device = devices[0]
+    for device in devices:
+        linop = Dense(weight, Dim("BMN"), ishape=Dim("BN"), oshape=Dim("BM")).to(device)
+
+        if todevice:
+            base_stream = torch.cuda.default_stream(base_device)
+            stream = streams[device]
+            linop.stream = stream
+            As[device] = (
+                ToDevice(
+                    idevice=device,
+                    odevice=base_device,
+                    ioshape=Dim("BM"),
+                    istream=stream,
+                    ostream=base_stream,
+                )
+                @ linop
+                @ ToDevice(
+                    idevice=base_device,
+                    odevice=device,
+                    ioshape=Dim("BN"),
+                    istream=base_stream,
+                    ostream=stream,
+                )
+            )
+        else:
+            As[device] = linop
+
+    # A.to(devices[0])
+    # A = create_batched_linop(
+    #     A, BatchSpec({"B": 3}, device_matrix=devices, base_device=devices[0])
+    # )
+
+    x = torch.randn(B, N, device=base_device)
+    with profile(
+        activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA],
+        on_trace_ready=lambda p: p.export_chrome_trace("./trace.json"),
+    ) as prof:
+        if todevice:
+            for i in range(10):
+                for device in devices:
+                    y = As[device](x)
+                time.sleep(0.2)
+            for device in devices:
+                torch.cuda.synchronize(device)
+        else:
+            # Manual
+            # - Want computation to occur on default stream of each device
+            # - In Pytorch, the Transfer is always registered on a stream of the SOURCE device
+            # - On the base device (where data starts and ends), transfer must occur on separate stream.
+            # - Transfer stream should not wait on the computation stream
+            for i in range(10):
+                base_stream = torch.cuda.default_stream(base_device)
+                for device in devices:
+                    target_stream = torch.cuda.default_stream(device)
+                    transfer_stream = streams[base_device]
+                    # ToDevice
+                    with torch.cuda.stream(transfer_stream):
+                        x2 = x.to(device, non_blocking=True)
+                    # Don't mess with x until transfer stream is done
+                    x.record_stream(transfer_stream)
+                    # Target should wait for transfer to complete before starting work
+                    target_stream.wait_stream(transfer_stream)
+
+                    # Linop
+                    with torch.cuda.stream(target_stream):
+                        x3 = As[device](x2)
+                    # Necessary if target_stream is not a default stream
+                    x2.record_stream(target_stream)
+
+                    # ToDevice
+                    # Using target stream here forces wait until linop computation is done.
+                    # Also remember that transfer is forced to be on a source device stream.
+                    with torch.cuda.stream(target_stream):
+                        out = x3.to(base_device, non_blocking=True)
+                    # Don't mess with x3 until transfer is done (may be unnecessary)
+                    x3.record_stream(target_stream)
+                    # Transfer stream should not wait for the target stream to complete the transfer
+                    # transfer_stream.wait_stream(target_stream) # NO
+
+                    # Instead, the base stream should wait
+                    base_stream.wait_stream(target_stream)
+
+                # time.sleep(0.2)
+            for device in devices:
+                torch.cuda.synchronize(device)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,10 @@ markers = [
 [tool.coverage.run]
 omit = ["*/tests/*"]
 
+[tool.isort]
+known_first_party = ["torchlinops"]
+no_lines_before = ["LOCALFOLDER"]
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/src/torchlinops/functional/_interp/grid.py
+++ b/src/torchlinops/functional/_interp/grid.py
@@ -531,7 +531,8 @@ def prep_grid_shapes(vals, locs, grid_size, width):
     npts = prod(locs_batch_shape)
 
     # Ensure locs are in [0, grid_size-1] in each dimension
-    locs = torch.remainder(locs, torch.tensor(grid_size, device=locs.device))
+    # NOTE: this causes gpu synchronization
+    # locs = torch.remainder(locs, torch.tensor(grid_size, device=locs.device))
 
     # Flatten input vals
     batch_shape = vals.shape[: -len(locs_batch_shape)]

--- a/src/torchlinops/functional/_interp/grid.py
+++ b/src/torchlinops/functional/_interp/grid.py
@@ -166,7 +166,7 @@ def get_block_width(kernel_width: tuple[float, ...], ndim: int, is_complex: bool
         ),
     },
 )
-@triton.jit
+@triton.jit  # pragma: no cover
 def _grid1d(
     in_ptr,
     pts_ptr,
@@ -255,7 +255,7 @@ def _grid1d(
         ),
     },
 )
-@triton.jit
+@triton.jit  # pragma: no cover
 def _grid2d(
     in_ptr,
     pts_ptr,
@@ -377,7 +377,7 @@ def _grid2d(
         ),
     },
 )
-@triton.jit
+@triton.jit  # pragma: no cover
 def _grid3d(
     in_ptr,
     pts_ptr,

--- a/src/torchlinops/functional/_interp/kernels.py
+++ b/src/torchlinops/functional/_interp/kernels.py
@@ -148,19 +148,19 @@ def weights_torch(
 
 
 # Euclidean norm
-@triton.jit
+@triton.jit  # pragma: no cover
 def norm1d(vx):
     return tl.abs(vx)
 
 
-@triton.jit
+@triton.jit  # pragma: no cover
 def norm2d(vx, vy):
     absvx = tl.abs(vx)
     absvy = tl.abs(vy)
     return tl.sqrt(absvx * absvx + absvy * absvy)
 
 
-@triton.jit
+@triton.jit  # pragma: no cover
 def norm3d(vx, vy, vz):
     absvx = tl.abs(vx)
     absvy = tl.abs(vy)
@@ -168,7 +168,7 @@ def norm3d(vx, vy, vz):
     return tl.sqrt(absvx * absvx + absvy * absvy + absvz * absvz)
 
 
-@triton.jit
+@triton.jit  # pragma: no cover
 def kaiser_bessel(x, beta):
     """Vectorized kaiser-bessel kernel implementation
     Parameters
@@ -237,7 +237,7 @@ def kaiser_bessel(x, beta):
     return tl.where(smallmask, small, big)
 
 
-@triton.jit
+@triton.jit  # pragma: no cover
 def spline(x):
     return tl.maximum(1.0 - tl.abs(x), 0.0)
 
@@ -256,7 +256,7 @@ def _apply_default_kernel_params(kernel: KernelTypeStr, kernel_params: dict):
     return kernel_params
 
 
-@triton.jit
+@triton.jit  # pragma: no cover
 def weights1d(
     x_target,
     x_kernel_width,  # width to load
@@ -283,7 +283,7 @@ def weights1d(
     return weights, x_range, x_mask
 
 
-@triton.jit
+@triton.jit  # pragma: no cover
 def weights2d(
     x_target,
     y_target,
@@ -329,7 +329,7 @@ def weights2d(
     return weights, x_range, y_range, x_mask, y_mask
 
 
-@triton.jit
+@triton.jit  # pragma: no cover
 def weights3d(
     x_target,
     y_target,
@@ -384,7 +384,7 @@ def weights3d(
     return weights, x_range, y_range, z_range, x_mask, y_mask, z_mask
 
 
-@triton.jit
+@triton.jit  # pragma: no cover
 def get_neighborhood(target, kernel_width, base_range):
     lower = target - (kernel_width / 2.0)
     lower = tl.ceil(lower)
@@ -392,7 +392,7 @@ def get_neighborhood(target, kernel_width, base_range):
     return base_range + lower
 
 
-@triton.jit
+@triton.jit  # pragma: no cover
 def mod_pos(t, n):
     """Modulo but ensures positive return value"""
     return tl.where(t >= 0, t % n, (t % n) + n)

--- a/src/torchlinops/functional/_interp/ungrid.py
+++ b/src/torchlinops/functional/_interp/ungrid.py
@@ -590,7 +590,8 @@ def prep_ungrid_shapes(vals, locs, width):
     nbatch = vals_flat.shape[0]
 
     # Ensure locs are in [0, grid_size-1] in each dimension
-    locs = torch.remainder(locs, torch.tensor(grid_size, device=locs.device))
+    # NOTE: This causes gpu synchronization
+    # locs = torch.remainder(locs, torch.tensor(grid_size, device=locs.device))
 
     # Handle locs shapes
     locs_batch_shape = locs.shape[:-1]

--- a/src/torchlinops/functional/_interp/ungrid.py
+++ b/src/torchlinops/functional/_interp/ungrid.py
@@ -161,7 +161,7 @@ def get_block_width(kernel_width: tuple[float, ...], ndim: int, is_complex: bool
         ),
     },
 )
-@triton.jit
+@triton.jit  # pragma: no cover
 def _ungrid1d(
     in_ptr,
     pts_ptr,
@@ -252,7 +252,7 @@ def _ungrid1d(
         ),
     },
 )
-@triton.jit
+@triton.jit  # pragma: no cover
 def _ungrid2d(
     in_ptr,
     pts_ptr,
@@ -371,7 +371,7 @@ def _ungrid2d(
         ),
     },
 )
-@triton.jit
+@triton.jit  # pragma: no cover
 def _ungrid3d(
     in_ptr,
     pts_ptr,
@@ -513,7 +513,7 @@ def _ungrid3d(
 #         ),
 #     },
 # )
-# @triton.jit
+# @triton.jit # pragma: no cover
 # def _ungridnd(
 #     in_ptr,
 #     pts_ptr,
@@ -536,7 +536,7 @@ def _ungrid3d(
 #     ...
 
 
-# @triton.jit
+# @triton.jit # pragma: no cover
 # def ungrid_nd_helper(
 #     in_ptr, kernel_width_ptr, size_ptr, dim, BLOCK_WIDTH, KERNEL, beta
 # ):
@@ -565,7 +565,7 @@ def _ungrid3d(
 #     # TODO: return dot product of vals and weights
 
 
-@triton.jit
+@triton.jit  # pragma: no cover
 def one_hot(i, BLOCK_WIDTH: tl.constexpr, dtype: tl.constexpr = tl.float32):
     idx = tl.arange(0, BLOCK_WIDTH)
     return tl.where(idx == i, 1, 0).to(dtype)

--- a/src/torchlinops/functional/_unfold/casting.py
+++ b/src/torchlinops/functional/_unfold/casting.py
@@ -11,7 +11,7 @@ except ImportError:
 __all__ = ["scalar_cast"]
 
 
-@triton.jit
+@triton.jit  # pragma: no cover
 def scalar_cast(t, dtype):
     """Replaces .to(). Necessary to avoid certain optimizations
     in cases when the inputs to the function are 1

--- a/src/torchlinops/functional/_unfold/fold.py
+++ b/src/torchlinops/functional/_unfold/fold.py
@@ -147,7 +147,7 @@ def _get_grid(ndim: int, nbatch, im_size):
         ),
     },
 )
-@triton.jit
+@triton.jit  # pragma: no cover
 def _fold1d(
     in_ptr,
     out_ptr,
@@ -229,7 +229,7 @@ def _fold1d(
         ),
     },
 )
-@triton.jit
+@triton.jit  # pragma: no cover
 def _fold2d(
     in_ptr,
     out_ptr,
@@ -341,7 +341,7 @@ def _fold2d(
         ),
     },
 )
-@triton.jit
+@triton.jit  # pragma: no cover
 def _fold3d(
     in_ptr,
     out_ptr,
@@ -475,7 +475,7 @@ def _fold3d(
     tl.store(out_ptr + out_offset + out_range, output, out_mask)
 
 
-@triton.jit
+@triton.jit  # pragma: no cover
 def cdiv(a, b):
     return tl.cast(tl.ceil(a / b), tl.int32)
 

--- a/src/torchlinops/functional/_unfold/unfold.py
+++ b/src/torchlinops/functional/_unfold/unfold.py
@@ -162,7 +162,7 @@ def _get_grid(ndim: int, nbatch, nblocks: tuple[int, ...]):
         ),
     },
 )
-@triton.jit
+@triton.jit  # pragma: no cover
 def _unfold1d(
     in_ptr,
     out_ptr,
@@ -227,7 +227,7 @@ def _unfold1d(
         in_blk_ptr = tl.advance(in_blk_ptr, (0, x_stride))
 
 
-@triton.jit
+@triton.jit  # pragma: no cover
 def load_subblock1d(in_blk_ptr, x_idx: int, X_BLOCK_SIZE: tl.constexpr):
     return tl.load(
         in_blk_ptr.advance((0, x_idx * X_BLOCK_SIZE)),
@@ -252,7 +252,7 @@ def load_subblock1d(in_blk_ptr, x_idx: int, X_BLOCK_SIZE: tl.constexpr):
         ),
     },
 )
-@triton.jit
+@triton.jit  # pragma: no cover
 def _unfold2d(
     in_ptr,
     out_ptr,
@@ -346,7 +346,7 @@ def _unfold2d(
         in_blk_ptr = tl.advance(in_blk_ptr, (0, x_stride, 0))
 
 
-@triton.jit
+@triton.jit  # pragma: no cover
 def load_subblock2d(in_blk_ptr, x_idx, y_idx, X_BLOCK_SIZE, Y_BLOCK_SIZE):
     return tl.load(
         in_blk_ptr.advance((0, x_idx * X_BLOCK_SIZE, y_idx * Y_BLOCK_SIZE)),
@@ -377,7 +377,7 @@ def load_subblock2d(in_blk_ptr, x_idx, y_idx, X_BLOCK_SIZE, Y_BLOCK_SIZE):
         ),
     },
 )
-@triton.jit
+@triton.jit  # pragma: no cover
 def _unfold3d(
     in_ptr,
     out_ptr,
@@ -509,7 +509,7 @@ def _unfold3d(
         in_blk_ptr = tl.advance(in_blk_ptr, (0, x_stride, 0, 0))
 
 
-@triton.jit
+@triton.jit  # pragma: no cover
 def load_subblock3d(
     in_blk_ptr, x_idx, y_idx, z_idx, X_BLOCK_SIZE, Y_BLOCK_SIZE, Z_BLOCK_SIZE
 ):

--- a/src/torchlinops/linops/array_to_blocks.py
+++ b/src/torchlinops/linops/array_to_blocks.py
@@ -46,31 +46,28 @@ class ArrayToBlocks(NamedLinop):
         else:
             self.mask = mask
 
-    def forward(self, x):
-        return self.fn(self, x)
-
     @staticmethod
-    def fn(linop, x):
+    def fn(arraytoblocks, x, /):
         return F.array_to_blocks(
             x,
-            linop.block_size,
-            linop.stride,
-            linop.mask,
+            arraytoblocks.block_size,
+            arraytoblocks.stride,
+            arraytoblocks.mask,
         )
 
     @staticmethod
-    def adj_fn(linop, x):
+    def adj_fn(arraytoblocks, x, /):
         return F.blocks_to_array(
             x,
-            linop.grid_size,
-            linop.block_size,
-            linop.stride,
-            linop.mask,
+            arraytoblocks.grid_size,
+            arraytoblocks.block_size,
+            arraytoblocks.stride,
+            arraytoblocks.mask,
         )
 
     @staticmethod
-    def normal_fn(linop, x):
-        return linop.adj_fn(linop, linop.fn(linop, x))
+    def normal_fn(arraytoblocks, x, /):
+        return arraytoblocks.adj_fn(arraytoblocks, arraytoblocks.fn(arraytoblocks, x))
 
     def split_forward(self, ibatch, obatch):
         return copy(self)
@@ -123,35 +120,32 @@ class BlocksToArray(NamedLinop):
         else:
             self.mask = mask
 
-    def forward(self, x):
-        return self.fn(self, x)
-
     @staticmethod
-    def fn(linop, x):
+    def fn(blockstoarray, x, /):
         return F.blocks_to_array(
             x,
-            linop.grid_size,
-            linop.block_size,
-            linop.stride,
-            linop.mask,
+            blockstoarray.grid_size,
+            blockstoarray.block_size,
+            blockstoarray.stride,
+            blockstoarray.mask,
         )
 
     @staticmethod
-    def adj_fn(linop, x):
-        if x.shape[-linop.ndim :] != linop.grid_size:
+    def adj_fn(blockstoarray, x, /):
+        if x.shape[-blockstoarray.ndim :] != blockstoarray.grid_size:
             raise RuntimeError(
-                f"BlocksToArray expected input with full size {linop.grid_size} but got {x.shape}"
+                f"BlocksToArray expected input with full size {blockstoarray.grid_size} but got {x.shape}"
             )
         return F.array_to_blocks(
             x,
-            linop.block_size,
-            linop.stride,
-            linop.mask,
+            blockstoarray.block_size,
+            blockstoarray.stride,
+            blockstoarray.mask,
         )
 
-    @staticmethod
-    def normal_fn(linop, x):
-        return linop.adj_fn(linop, linop.fn(linop, x))
+    # @staticmethod
+    # def normal_fn(blockstoarray, x, /):
+    #     return blockstoarray.adj_fn(blockstoarray, blockstoarray.fn(blockstoarray, x))
 
     def split_forward(self, ibatch, obatch):
         return copy(self)

--- a/src/torchlinops/linops/array_to_blocks.py
+++ b/src/torchlinops/linops/array_to_blocks.py
@@ -143,10 +143,6 @@ class BlocksToArray(NamedLinop):
             blockstoarray.mask,
         )
 
-    # @staticmethod
-    # def normal_fn(blockstoarray, x, /):
-    #     return blockstoarray.adj_fn(blockstoarray, blockstoarray.fn(blockstoarray, x))
-
     def split_forward(self, ibatch, obatch):
         return copy(self)
 

--- a/src/torchlinops/linops/breakpt.py
+++ b/src/torchlinops/linops/breakpt.py
@@ -10,9 +10,6 @@ class BreakpointLinop(NamedLinop):
     def __init__(self, ioshape: Optional[Shape] = None):
         super().__init__(NS(ioshape))
 
-    def forward(self, x):
-        return self.fn(self, x)
-
     @staticmethod
     def fn(linop, x, /):
         breakpoint()

--- a/src/torchlinops/linops/chain.py
+++ b/src/torchlinops/linops/chain.py
@@ -141,24 +141,6 @@ class Chain(NamedLinop):
         ]
         return chain.H.split_forward(obatches, ibatches).H
 
-    # DEPRECATED/TODO: Remove
-    # @staticmethod
-    # def split_fn(chain, *iobatchesdata):
-    #     """Return split versions of the data that can be passed
-    #     into fn and adj_fn to produce split versions
-    #     """
-    #     ibatches = iobatchesdata[: len(iobatchesdata) // 3]
-    #     obatches = iobatchesdata[len(iobatchesdata) // 3 : len(iobatchesdata) * 2 // 3]
-    #     data = iobatchesdata[len(iobatchesdata) * 2 // 3 :]
-    #     return chain.split_forward_fn(ibatches, obatches, data)
-
-    # @staticmethod
-    # def adj_split_fn(chain, *iobatchesdata):
-    #     ibatches = iobatchesdata[: len(iobatchesdata) // 3]
-    #     obatches = iobatchesdata[len(iobatchesdata) // 3 : len(iobatchesdata) * 2 // 3]
-    #     data = iobatchesdata[len(iobatchesdata) * 2 // 3]
-    #     return chain.split_forward_fn(obatches, ibatches, data)
-
     @property
     def shape(self):
         return NS(self.linops[0].ishape, self.linops[-1].oshape)

--- a/src/torchlinops/linops/chain.py
+++ b/src/torchlinops/linops/chain.py
@@ -40,13 +40,13 @@ class Chain(NamedLinop):
     @staticmethod
     def fn(chain, x: torch.Tensor, /):
         for linop in chain.linops:
-            x = linop.fn(linop, x)
+            x = linop(x)
         return x
 
     @staticmethod
     def adj_fn(chain, x: torch.Tensor, /):
         for linop in reversed(chain.linops):
-            x = linop.adj_fn(linop, x)
+            x = linop.H(x)
         return x
 
     # @staticmethod

--- a/src/torchlinops/linops/concat.py
+++ b/src/torchlinops/linops/concat.py
@@ -92,9 +92,6 @@ class Concat(NamedLinop):
         self.idim_idx = self._infer_dim_idx(self.idim, ishape)
         self.odim_idx = self._infer_dim_idx(self.odim, oshape)
 
-    def forward(self, x):
-        return self.fn(self, x)
-
     @staticmethod
     def fn(concat, x):
         return concat._fn(
@@ -147,9 +144,9 @@ class Concat(NamedLinop):
             y += linop(xi)
         return y
 
-    @staticmethod
-    def normal_fn(concat, x):
-        return concat.adj_fn(concat, concat.fn(concat, x))
+    # @staticmethod
+    # def normal_fn(concat, x):
+    #     return concat.adj_fn(concat, concat.fn(concat, x))
 
     def size(self, dim):
         return self.size_fn(dim)

--- a/src/torchlinops/linops/concat.py
+++ b/src/torchlinops/linops/concat.py
@@ -144,10 +144,6 @@ class Concat(NamedLinop):
             y += linop(xi)
         return y
 
-    # @staticmethod
-    # def normal_fn(concat, x):
-    #     return concat.adj_fn(concat, concat.fn(concat, x))
-
     def size(self, dim):
         return self.size_fn(dim)
 
@@ -424,7 +420,7 @@ def partition_slices(partition, slc):
         )
     if slc.step is not None and slc.step != 1:
         raise NotImplementedError(
-            f"Partition slicing with step != 1 is not currently supported."
+            "Partition slicing with step != 1 is not currently supported."
         )
 
     start, stop = get_slice_start_stop(slc, partition[-1])

--- a/src/torchlinops/linops/dense.py
+++ b/src/torchlinops/linops/dense.py
@@ -88,10 +88,6 @@ class Dense(NamedLinop):
     def adj_fn(dense, x, /):
         return einsum(x, dense.weight.conj(), dense.adj_einstr)
 
-    # @staticmethod
-    # def normal_fn(dense, x, /):
-    #     return dense.adj_fn(dense, dense.fn(dense, x))
-
     def adjoint(self):
         adj = copy(self)
         adj.weight = nn.Parameter(

--- a/src/torchlinops/linops/dense.py
+++ b/src/torchlinops/linops/dense.py
@@ -77,20 +77,20 @@ class Dense(NamedLinop):
         """
         return " ".join(str(s) for s in arr)
 
-    def forward(self, x):
-        return self.fn(self, x, self.weight)
+    # def forward(self, x):
+    #     return self.fn(self, x, self.weight)
 
     @staticmethod
-    def fn(linop, x, /, weight):
-        return einsum(x, weight, linop.forward_einstr)
+    def fn(dense, x, /):
+        return einsum(x, dense.weight, dense.forward_einstr)
 
     @staticmethod
-    def adj_fn(linop, x, /, weight):
-        return einsum(x, weight.conj(), linop.adj_einstr)
+    def adj_fn(dense, x, /):
+        return einsum(x, dense.weight.conj(), dense.adj_einstr)
 
-    @staticmethod
-    def normal_fn(linop, x, /, weight):
-        return linop.adj_fn(linop.fn(x, weight), weight)
+    # @staticmethod
+    # def normal_fn(dense, x, /):
+    #     return dense.adj_fn(dense, dense.fn(dense, x))
 
     def adjoint(self):
         adj = copy(self)

--- a/src/torchlinops/linops/dense.py
+++ b/src/torchlinops/linops/dense.py
@@ -77,9 +77,6 @@ class Dense(NamedLinop):
         """
         return " ".join(str(s) for s in arr)
 
-    # def forward(self, x):
-    #     return self.fn(self, x, self.weight)
-
     @staticmethod
     def fn(dense, x, /):
         return einsum(x, dense.weight, dense.forward_einstr)

--- a/src/torchlinops/linops/device.py
+++ b/src/torchlinops/linops/device.py
@@ -65,7 +65,9 @@ class ToDevice(NamedLinop):
             ostream.wait_stream(istream)
             return out
 
-        return x.to(odevice, non_blocking=True)
+        if odevice.type == "cuda":
+            return x.to(odevice, non_blocking=True)
+        return x.to(odevice)
 
     @staticmethod
     def fn(todevice, x, /):

--- a/src/torchlinops/linops/device.py
+++ b/src/torchlinops/linops/device.py
@@ -1,10 +1,14 @@
-from typing import Optional
 from copy import copy
+from dataclasses import dataclass, field
+from typing import Optional
+
 import torch
-from .namedlinop import NamedLinop
+from torch import Tensor
+
+from torchlinops.utils import INDENT
 from .identity import Identity
 from .nameddim import ELLIPSES, NS, Shape
-from torchlinops.utils import INDENT
+from .namedlinop import NamedLinop
 
 __all__ = ["ToDevice"]
 
@@ -26,7 +30,7 @@ class ToDevice(NamedLinop):
             raise RuntimeError(
                 f"Got input to ToDevice on {x.device} but expected {linop.idevice}"
             )
-        return x.to(linop.odevice)
+        return x.to(linop.odevice, non_blocking=True)
 
     @staticmethod
     def adj_fn(linop, x, /):
@@ -34,7 +38,7 @@ class ToDevice(NamedLinop):
             raise RuntimeError(
                 f"Got input to ToDevice on {x.device} but expected {linop.odevice}"
             )
-        return x.to(linop.idevice)
+        return x.to(linop.idevice, non_blocking=True)
 
     def adjoint(self):
         adj = copy(self)

--- a/src/torchlinops/linops/device.py
+++ b/src/torchlinops/linops/device.py
@@ -41,18 +41,6 @@ class ToDevice(NamedLinop):
             self.istream = None
             self.ostream = None
 
-        #     self.i2o_stream = (
-        #         i2o_stream if i2o_stream is not None else Stream(self.odevice)
-        #     )
-        #     self.o2i_stream = (
-        #         o2i_stream if o2i_stream is not None else Stream(self.idevice)
-        #     )
-        #     self.wait_on_input = wait_on_input
-        # else:
-        #     self.i2o_stream = None
-        #     self.o2i_stream = None
-        #     self.wait_on_input = False
-
     @staticmethod
     def fn(linop, x, /):
         if x.device != linop.idevice:

--- a/src/torchlinops/linops/diagonal.py
+++ b/src/torchlinops/linops/diagonal.py
@@ -80,20 +80,17 @@ class Diagonal(NamedLinop):
         self._shape.oshape = val
         self._shape.ishape = val
 
-    def forward(self, x):
-        return self.fn(self, x, self.weight)
+    @staticmethod
+    def fn(diagonal, x, /):
+        return x * diagonal.weight
 
     @staticmethod
-    def fn(linop, x, /, weight):
-        return x * weight
+    def adj_fn(diagonal, x, /):
+        return x * torch.conj(diagonal.weight)
 
     @staticmethod
-    def adj_fn(linop, x, /, weight):
-        return x * torch.conj(weight)
-
-    @staticmethod
-    def normal_fn(linop, x, /, weight):
-        return x * torch.abs(weight) ** 2
+    def normal_fn(diagonal, x, /):
+        return x * torch.abs(diagonal.weight) ** 2
 
     def adjoint(self):
         adj = copy(self)

--- a/src/torchlinops/linops/einops.py
+++ b/src/torchlinops/linops/einops.py
@@ -41,9 +41,6 @@ class Rearrange(NamedLinop):
     def axes_lengths(self):
         return self._shape.axes_lengths
 
-    def forward(self, x):
-        return self.fn(self, x)
-
     @staticmethod
     def fn(linop, x, /):
         axes_lengths = {str(k): v for k, v in linop.axes_lengths.items()}
@@ -110,17 +107,14 @@ class SumReduce(NamedLinop):
             f"Reduce must be over at least one dimension: got {self.ishape} -> {self.oshape}"
         )
 
-    def forward(self, x):
-        return self.fn(self, x)
-
     @staticmethod
-    def fn(linop, x, /):
-        x = reduce(x, f"{linop.ipattern} -> {linop.opattern}", "sum")
+    def fn(sumreduce, x, /):
+        x = reduce(x, f"{sumreduce.ipattern} -> {sumreduce.opattern}", "sum")
         return x
 
     @staticmethod
-    def adj_fn(linop, x, /):
-        x = repeat(x, f"{linop.opattern} -> {linop.adj_ipattern}")
+    def adj_fn(sumreduce, x, /):
+        x = repeat(x, f"{sumreduce.opattern} -> {sumreduce.adj_ipattern}")
         return x
 
     def split_forward(self, ibatch, obatch):

--- a/src/torchlinops/linops/fft.py
+++ b/src/torchlinops/linops/fft.py
@@ -63,9 +63,6 @@ class FFT(NamedLinop):
     def batch_shape(self):
         return self._shape.lookup("batch_shape")
 
-    # def forward(self, x, /):
-    #     return self.fn(self, x)
-
     @staticmethod
     def fn(linop, x):
         if linop.centered:

--- a/src/torchlinops/linops/fft.py
+++ b/src/torchlinops/linops/fft.py
@@ -63,8 +63,8 @@ class FFT(NamedLinop):
     def batch_shape(self):
         return self._shape.lookup("batch_shape")
 
-    def forward(self, x, /):
-        return self.fn(self, x)
+    # def forward(self, x, /):
+    #     return self.fn(self, x)
 
     @staticmethod
     def fn(linop, x):

--- a/src/torchlinops/linops/identity.py
+++ b/src/torchlinops/linops/identity.py
@@ -10,8 +10,8 @@ class Identity(NamedLinop):
     def __init__(self, ishape=("...",), oshape=None):
         super().__init__(NS(ishape, oshape))
 
-    def forward(self, x):
-        return self.fn(self, x)
+    # def forward(self, x):
+    #     return self.fn(self, x)
 
     def adjoint(self):
         return self
@@ -29,9 +29,9 @@ class Identity(NamedLinop):
     def adj_fn(linop, x, /):
         return x
 
-    @staticmethod
-    def normal_fn(linop, x, /):
-        return x
+    # @staticmethod
+    # def normal_fn(linop, x, /):
+    #     return x
 
     def split_forward(self, ibatch, obatch):
         # TODO: Allow non-diagonal splitting

--- a/src/torchlinops/linops/identity.py
+++ b/src/torchlinops/linops/identity.py
@@ -10,9 +10,6 @@ class Identity(NamedLinop):
     def __init__(self, ishape=("...",), oshape=None):
         super().__init__(NS(ishape, oshape))
 
-    # def forward(self, x):
-    #     return self.fn(self, x)
-
     def adjoint(self):
         return self
 
@@ -29,9 +26,10 @@ class Identity(NamedLinop):
     def adj_fn(linop, x, /):
         return x
 
-    # @staticmethod
-    # def normal_fn(linop, x, /):
-    #     return x
+    @staticmethod
+    def normal_fn(linop, x, /):
+        # A bit faster
+        return x
 
     def split_forward(self, ibatch, obatch):
         # TODO: Allow non-diagonal splitting

--- a/src/torchlinops/linops/interp.py
+++ b/src/torchlinops/linops/interp.py
@@ -56,21 +56,20 @@ class Interpolate(NamedLinop):
             "kernel_params": kernel_params,
         }
 
-    def forward(self, x):
-        return self.fn(self, x, self.locs)
+    @staticmethod
+    def fn(interp, x, /):
+        return F.interpolate(x, interp.locs, **interp._interp_params)
 
     @staticmethod
-    def fn(linop, x, /, locs):
-        return F.interpolate(x, locs, **linop._interp_params)
+    def adj_fn(interp, x, /):
+        return F.interpolate_adjoint(
+            x, interp.locs, interp.grid_size, **interp._interp_params
+        )
 
-    @staticmethod
-    def adj_fn(linop, x, /, locs):
-        return F.interpolate_adjoint(x, locs, linop.grid_size, **linop._interp_params)
-
-    @staticmethod
-    def normal_fn(linop, x, /, locs):
-        return linop.adj_fn(linop, linop.fn(linop, x, locs), locs)
-        # return linop.adj_fn(linop, linop.fn(linop, x, locs), locs)
+    # @staticmethod
+    # def normal_fn(interp, x, /):
+    #     return interp.adj_fn(interp, interp.fn(interp, x, interp.locs), interp.locs)
+    # return linop.adj_fn(linop, linop.fn(linop, x, locs), locs)
 
     def split_forward(self, ibatch, obatch):
         return type(self)(

--- a/src/torchlinops/linops/interp.py
+++ b/src/torchlinops/linops/interp.py
@@ -66,11 +66,6 @@ class Interpolate(NamedLinop):
             x, interp.locs, interp.grid_size, **interp._interp_params
         )
 
-    # @staticmethod
-    # def normal_fn(interp, x, /):
-    #     return interp.adj_fn(interp, interp.fn(interp, x, interp.locs), interp.locs)
-    # return linop.adj_fn(linop, linop.fn(linop, x, locs), locs)
-
     def split_forward(self, ibatch, obatch):
         return type(self)(
             self.split_forward_fn(ibatch, obatch, self.locs),

--- a/src/torchlinops/linops/nufft.py
+++ b/src/torchlinops/linops/nufft.py
@@ -194,9 +194,13 @@ class NUFFT(Chain):
         self.interp = interp
 
     def adjoint(self):
-        adj = super(Chain, self).adjoint()
-        linops = [linop.H for linop in adj.linops]
-        linops.reverse()
+        # Hybrid of chain adjoint and namedlinop adjoint
+        adj = copy(self)
+        adj._shape = adj._shape.H
+
+        linops = list(linop.adjoint() for linop in reversed(self.linops))
+        # linops = [linop.H for linop in adj.linops]
+        # linops.reverse()
         adj.linops = nn.ModuleList(linops)
         return adj
 

--- a/src/torchlinops/linops/nufft.py
+++ b/src/torchlinops/linops/nufft.py
@@ -199,8 +199,6 @@ class NUFFT(Chain):
         adj._shape = adj._shape.H
 
         linops = list(linop.adjoint() for linop in reversed(self.linops))
-        # linops = [linop.H for linop in adj.linops]
-        # linops.reverse()
         adj.linops = nn.ModuleList(linops)
         return adj
 

--- a/src/torchlinops/linops/pad_last.py
+++ b/src/torchlinops/linops/pad_last.py
@@ -69,27 +69,23 @@ class PadLast(NamedLinop):
         # Need to reverse crop_slice because padding is reversed
         self.crop_slice = crop_slice_from_pad(self.pad)
 
-    def forward(self, x):
-        """Pad the last n dimensions of x"""
-        return self.fn(self, x)
-
     @staticmethod
-    def fn(linop, x, /):
-        if tuple(x.shape[-linop.D :]) != linop.im_size:
+    def fn(padlast, x, /):
+        if tuple(x.shape[-padlast.D :]) != padlast.im_size:
             raise ValueError(
-                f"Mismatched shapes: expected {linop.im_size} but got {x.shape[-linop.D :]}"
+                f"Mismatched shapes: expected {padlast.im_size} but got {x.shape[-padlast.D :]}"
             )
-        pad = linop.pad + [0, 0] * (x.ndim - linop.D)
+        pad = padlast.pad + [0, 0] * (x.ndim - padlast.D)
         return F.pad(x, pad)
 
     @staticmethod
-    def adj_fn(linop, y, /):
+    def adj_fn(padlast, y, /):
         """Crop the last n dimensions of y"""
-        if tuple(y.shape[-linop.D :]) != linop.pad_im_size:
+        if tuple(y.shape[-padlast.D :]) != padlast.pad_im_size:
             raise ValueError(
-                f"Mismatched shapes: expected {linop.pad_im_size} but got {y.shape[-linop.D :]}"
+                f"Mismatched shapes: expected {padlast.pad_im_size} but got {y.shape[-padlast.D :]}"
             )
-        slc = [slice(None)] * (y.ndim - linop.D) + linop.crop_slice
+        slc = [slice(None)] * (y.ndim - padlast.D) + padlast.crop_slice
         return y[slc]
 
     def adjoint(self):

--- a/src/torchlinops/linops/sampling.py
+++ b/src/torchlinops/linops/sampling.py
@@ -75,16 +75,13 @@ class Sampling(NamedLinop):
         idx = F.canonicalize_idx(idx, dim=-1)
         return cls(idx, *args, **kwargs)
 
-    def forward(self, x):
-        return self.fn(self, x, tuple(self.idx))
+    @staticmethod
+    def fn(sampling, x, /):
+        return F.index(x, tuple(sampling.idx))
 
     @staticmethod
-    def fn(linop, x, idx):
-        return F.index(x, idx)
-
-    @staticmethod
-    def adj_fn(linop, x, idx):
-        return F.index_adjoint(x, idx, linop.input_size)
+    def adj_fn(sampling, x, /):
+        return F.index_adjoint(x, tuple(sampling.idx), sampling.input_size)
 
     def split_forward(self, ibatch, obatch):
         if self._shape.output_shape == ELLIPSES:

--- a/src/torchlinops/linops/split.py
+++ b/src/torchlinops/linops/split.py
@@ -50,23 +50,6 @@ class BatchSpec:
             return device_matrix
         return None
 
-    # @staticmethod
-    # def linop_to_device(
-    #     linop, device, base_device, memory_aware: bool = True, storage_map=None
-    # ):
-    #     linop, storage_map = linop.to(
-    #         device,
-    #         memory_aware=memory_aware,
-    #         storage_map=storage_map,
-    #         return_storage_map=True,
-    #     )
-    #     linop = (
-    #         ToDevice(device, base_device, linop.oshape)
-    #         @ linop
-    #         @ ToDevice(base_device, device, linop.ishape)
-    #     )
-    #     return linop, storage_map
-
 
 def create_batched_linop(linop, batch_specs: BatchSpec | list[BatchSpec], _mmap=None):
     """

--- a/src/torchlinops/linops/split.py
+++ b/src/torchlinops/linops/split.py
@@ -107,10 +107,10 @@ def create_batched_linop(linop, batch_specs: BatchSpec | list[BatchSpec], _mmap=
                 base_stream = batch_spec.base_stream
                 target_stream = target_streams[device]
                 tiled_linop.stream = target_stream
-                wait_event = Event()  # Trigger start of linops
+                if wait_event is None:
+                    wait_event = Event()  # Trigger start of linops
             else:
                 base_stream = transfer_stream = target_stream = None
-                wait_event = None
             tiled_linop = (
                 ToDevice(
                     device,

--- a/src/torchlinops/linops/stack.py
+++ b/src/torchlinops/linops/stack.py
@@ -86,11 +86,8 @@ class Stack(NamedLinop):
             idx = None
         return dim, idx, shape
 
-    def forward(self, x):
-        return self.fn(self, x)
-
     @staticmethod
-    def fn(stack, x):
+    def fn(stack, x, /):
         return stack._fn(
             x,
             stack.linops,
@@ -99,7 +96,7 @@ class Stack(NamedLinop):
         )
 
     @staticmethod
-    def adj_fn(stack, x):
+    def adj_fn(stack, x, /):
         adj_linops = [linop.H for linop in stack.linops]
         return stack._fn(
             x,
@@ -134,10 +131,6 @@ class Stack(NamedLinop):
         for xi, linop in zip(xs, linops):
             y += linop(xi)
         return y
-
-    @staticmethod
-    def normal_fn(stack, x):
-        return stack.adj_fn(stack, stack.fn(stack, x))
 
     def size(self, dim):
         return self.size_fn(dim)
@@ -322,6 +315,7 @@ class Stack(NamedLinop):
             output += INDENT.indent(f"idim = {self.idim}, odim = {self.odim}\n")
         output += INDENT.indent(")")
         return output
+
 
 def strict_update(d1: Mapping, d2: Mapping) -> Mapping:
     """Strictly updates one dictionary with values from the other.

--- a/src/torchlinops/tests/test_device.py
+++ b/src/torchlinops/tests/test_device.py
@@ -22,3 +22,34 @@ def test_todevice():
     w = D2D.N(x)
     assert w.device == x.device
     print(D2D)
+
+
+@pytest.mark.gpu
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.device_count() < 2,
+    reason="2 GPUs are required for this test",
+)
+def test_todevice_streams():
+    idevice = torch.device("cuda:0")
+    odevice = torch.device("cuda:1")
+
+    D2D2 = ToDevice(idevice, odevice)
+
+    x = torch.randn(3, 4, device=idevice)
+
+    # Test with first device
+    y1 = D2D2(x)
+    assert y1.device == odevice
+
+    # Test with second device
+    z1 = D2D2.H(y1)
+    assert z1.device == idevice
+
+    w2 = D2D2.N(x)
+    assert w2.device == x.device
+
+    # Verify that the streams are used
+    assert D2D2.istream is not None
+    assert D2D2.ostream is not None
+
+    print(D2D2)

--- a/src/torchlinops/tests/test_split.py
+++ b/src/torchlinops/tests/test_split.py
@@ -72,3 +72,36 @@ def test_create_batched_linop_multi_device():
         Abatch_x = Abatch(x)
         Ax = A(x)
         assert Abatch_x.allclose(Ax, rtol=1e-3)
+
+
+@pytest.mark.gpu
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.device_count() < 2,
+    reason="At least 2 GPUs are required but not available",
+)
+def test_create_batched_linop_multi_device_gpu_only():
+    ishape = ("B", "N")
+    oshape = ("B", "M")
+    B = 10
+    M, N = (3, 7)
+    weight = torch.randn(B, M, N)
+    weightshape = ("B", "M", "N")
+    A = Dense(weight, weightshape, ishape, oshape).to(torch.device("cuda:0"))
+
+    Abatch = create_batched_linop(
+        A,
+        [
+            BatchSpec(
+                dict(N=2),
+                device_matrix=[torch.device("cuda:0"), torch.device("cuda:1")],
+                base_device=torch.device("cuda:0"),
+            ),
+            BatchSpec(dict(M=1)),
+        ],
+    )
+    for _ in range(10):
+        # Fuzzing with multiple retries
+        x = torch.randn(B, N, device=torch.device("cuda:0"))
+        Abatch_x = Abatch(x)
+        Ax = A(x)
+        assert Abatch_x.allclose(Ax, rtol=1e-3)

--- a/src/torchlinops/tests/test_split.py
+++ b/src/torchlinops/tests/test_split.py
@@ -66,5 +66,9 @@ def test_create_batched_linop_multi_device():
             BatchSpec(dict(M=1)),
         ],
     )
-    x = torch.randn(B, N)
-    assert Abatch(x).allclose(A(x), rtol=1e-3)
+    for _ in range(10):
+        # Fuzzing with multiple retries
+        x = torch.randn(B, N)
+        Abatch_x = Abatch(x)
+        Ax = A(x)
+        assert Abatch_x.allclose(Ax, rtol=1e-3)

--- a/src/torchlinops/utils/_log.py
+++ b/src/torchlinops/utils/_log.py
@@ -6,11 +6,12 @@ __all__ = ["setup_console_logger", "Indenter", "INDENT"]
 
 
 def setup_console_logger(
-    logger,
-    log_level: int,
+    logger=None,
+    log_level: int = logging.INFO,
     fmt: str = "%(asctime)s | %(name)s | %(levelname)s | %(message)s",
     handler_cls=logging.StreamHandler,
 ):
+    logger = logging.getLogger() if logger is None else logger
     logger.setLevel(log_level)
     formatter = logging.Formatter(fmt)
     for handler in logger.handlers:

--- a/src/torchlinops/utils/tests/test_device_movement.py
+++ b/src/torchlinops/utils/tests/test_device_movement.py
@@ -328,6 +328,7 @@ class TestMemoryAwareDeepCopy:
 
         assert not copied_module is module
 
+    @pytest.mark.xfail  # Non-parameter non-buffer tensors are not deepcopied
     def test_deepcopy_non_parameter_tensor(self):
         module = SimpleCopyModule()
         module.non_param_tensor = torch.Tensor([1, 2, 3])


### PR DESCRIPTION
This pull request includes a bunch of stuff related to multi-GPU execution.

## Improvements
* Cleaning up all the old-style `.forward(` implementations. All linop forward calls should now be routed through the base NamedLinop.forward().
* Adding a `stream` attribute and a `start_event` attribute for more granular control of linop execution in multi-GPU settings. [[1]](diffhunk://#diff-b7c19c165b02e4d1d6f75220b1bce2702805ee6f2312cd84bd8853d03e45cea4R56)
* Improved `split` and `create_batch_linop` to support multi-GPU settings (src/torchlinops/linops/split.py)
* Improved `ToDevice` to support non-blocking stream-based data transfer in addition to GPU-based data transfer. 
* Improved linop memory management when moving complex linops between devices (ModuleMemoryMap [[1]](diffhunk://#diff-4d81fcfd314f0303ad1a698addf159ec4a80c9f808fcd7f9915aa567087d816cR56))
* Commented out the modulo operation for locations in `prep_grid_shapes` and `prep_ungrid_shapes` to avoid unnecessary GPU synchronization, improving performance in grid/ungrid functions. [[1]](diffhunk://#diff-7aa9263a3fac7c0e13471d379434f18eb3f28b582f6bb761dbdd0da02606b33eL534-R535) [[2]](diffhunk://#diff-03515020f226a036489583f8f00df491e839829908f75735e66d8fc60adfac60L593-R594)

## Developer Scripts
* Added two new CUDA stream profiling scripts: `profile_streams_v2.py` and `profile_streams_v3.py` in the `dev/cuda_streams` directory. These scripts demonstrate advanced stream and device management for batched linear operators, including manual and linop-based approaches, and integrate PyTorch's profiler for performance analysis. [[1]](diffhunk://#diff-24999851c1f15b2be98244ec5896a1ffc789689263be177c5656c9212c8b3225R1-R48) [[2]](diffhunk://#diff-ea4b610fd0dc2f427bb68dc2e84414b1c81169ef8795347691bae5801a7c6003R1-R115)

## Infrastructure
* Updated `.github/workflows/test-python.yml` to trigger tests on both `push` and `pull_request` events for the `main` and `develop` branches, and added a conditional to ensure jobs only run for relevant events/branches. [[1]](diffhunk://#diff-70450661fa435b39492aab8bf651281084183f36f0a59598f05fec2b4523204bR8-R11) [[2]](diffhunk://#diff-70450661fa435b39492aab8bf651281084183f36f0a59598f05fec2b4523204bR20-R23)
* Annotated all `@triton.jit` kernel definitions with `# pragma: no cover` throughout the codebase (including files in `src/torchlinops/functional/_interp/`, `_unfold/`, and `_unfold/casting.py`) to exclude them from coverage reporting, as Triton kernels are not covered by standard Python coverage tools. [[1]](diffhunk://#diff-7aa9263a3fac7c0e13471d379434f18eb3f28b582f6bb761dbdd0da02606b33eL169-R169) [[2]](diffhunk://#diff-7aa9263a3fac7c0e13471d379434f18eb3f28b582f6bb761dbdd0da02606b33eL258-R258) [[3]](diffhunk://#diff-7aa9263a3fac7c0e13471d379434f18eb3f28b582f6bb761dbdd0da02606b33eL380-R380) [[4]](diffhunk://#diff-d293f68b76dfaefbbfbb19c23eba1afadfca66b61dd32a3b3e8a44b6bd36fe98L151-R171) [[5]](diffhunk://#diff-d293f68b76dfaefbbfbb19c23eba1afadfca66b61dd32a3b3e8a44b6bd36fe98L240-R240) [[6]](diffhunk://#diff-d293f68b76dfaefbbfbb19c23eba1afadfca66b61dd32a3b3e8a44b6bd36fe98L259-R259) [[7]](diffhunk://#diff-d293f68b76dfaefbbfbb19c23eba1afadfca66b61dd32a3b3e8a44b6bd36fe98L286-R286) [[8]](diffhunk://#diff-d293f68b76dfaefbbfbb19c23eba1afadfca66b61dd32a3b3e8a44b6bd36fe98L332-R332) [[9]](diffhunk://#diff-d293f68b76dfaefbbfbb19c23eba1afadfca66b61dd32a3b3e8a44b6bd36fe98L387-R395) [[10]](diffhunk://#diff-03515020f226a036489583f8f00df491e839829908f75735e66d8fc60adfac60L164-R164) [[11]](diffhunk://#diff-03515020f226a036489583f8f00df491e839829908f75735e66d8fc60adfac60L255-R255) [[12]](diffhunk://#diff-03515020f226a036489583f8f00df491e839829908f75735e66d8fc60adfac60L374-R374) [[13]](diffhunk://#diff-03515020f226a036489583f8f00df491e839829908f75735e66d8fc60adfac60L516-R516) [[14]](diffhunk://#diff-03515020f226a036489583f8f00df491e839829908f75735e66d8fc60adfac60L539-R539) [[15]](diffhunk://#diff-03515020f226a036489583f8f00df491e839829908f75735e66d8fc60adfac60L568-R568) [[16]](diffhunk://#diff-8b22819d2523720f475752e6a0115b22674ab8ed2c56f041e3d2e580ea0ce522L14-R14) [[17]](diffhunk://#diff-e5f652c988095a171cc6ddfe791c66e1abc917725daad7fb7a3da1316b4ad62dL150-R150) [[18]](diffhunk://#diff-e5f652c988095a171cc6ddfe791c66e1abc917725daad7fb7a3da1316b4ad62dL232-R232) [[19]](diffhunk://#diff-e5f652c988095a171cc6ddfe791c66e1abc917725daad7fb7a3da1316b4ad62dL344-R344) [[20]](diffhunk://#diff-e5f652c988095a171cc6ddfe791c66e1abc917725daad7fb7a3da1316b4ad62dL478-R478) [[21]](diffhunk://#diff-600a90e3a53fd06287c4eb213699c735e158aa53bb63b4ad4e7c48b8d9badbbdL165-R165) [[22]](diffhunk://#diff-600a90e3a53fd06287c4eb213699c735e158aa53bb63b4ad4e7c48b8d9badbbdL230-R230) [[23]](diffhunk://#diff-600a90e3a53fd06287c4eb213699c735e158aa53bb63b4ad4e7c48b8d9badbbdL255-R255) [[24]](diffhunk://#diff-600a90e3a53fd06287c4eb213699c735e158aa53bb63b4ad4e7c48b8d9badbbdL349-R349) [[25]](diffhunk://#diff-600a90e3a53fd06287c4eb213699c735e158aa53bb63b4ad4e7c48b8d9badbbdL380-R380)