### PR TITLE
refactor: remove split_forward, use tiles everywhere in split()

### DIFF
--- a/docs/explanations/copying_linops.md
+++ b/docs/explanations/copying_linops.md
@@ -4,7 +4,7 @@ Copying linops is a surprisingly difficult thing to achieve in a memory-efficien
 
 ## Basic shallow copy
 
-`copy.copy()` of a `NamedLinop` is the workhorse of the library. It is used internally by `adjoint()`, `normal()`, and many `split_forward()` implementations.
+`copy.copy()` of a `NamedLinop` is the workhorse of the library. It is used internally by `adjoint()`, `normal()`, and many `split()` implementations.
 
 A shallow copy:
 
@@ -29,7 +29,7 @@ def adjoint(self):
 The result is a new `NamedLinop` that represents $A^H$ but uses the exact same weight tensors as $A$. Modifying the weights of one will affect the other -- this is intentional and desirable, as the adjoint should always reflect the current state of the operator.
 
 !!! note
-    Many concrete linops override `split_forward` to call their own constructor via `type(self)(...)` rather than using `copy()`. This is because PyTorch's `copy` does not properly isolate `nn.Parameter` objects -- modifications to a shallow-copied parameter can propagate back to the original. Calling the constructor creates truly independent parameters that happen to reference the same tensor data.
+    Many concrete linops override `split` to call their own constructor via `type(linop)(...)` rather than using `copy()`. This is because PyTorch's `copy` does not properly isolate `nn.Parameter` objects -- modifications to a shallow-copied parameter can propagate back to the original. Calling the constructor creates truly independent parameters that happen to reference the same tensor data.
 
 ## Memory-aware deepcopy
 

--- a/docs/explanations/faq.md
+++ b/docs/explanations/faq.md
@@ -33,7 +33,7 @@ Subclass `NamedLinop` and implement:
 1. **`__init__`**: Call `super().__init__(NS(ishape, oshape))` to set the shape.
 2. **`fn` (staticmethod)**: The forward pass, `fn(linop, x) -> y`.
 3. **`adj_fn` (staticmethod)**: The adjoint pass, `adj_fn(linop, x) -> y`.
-4. **`split_forward`** (optional): How to split along named dimensions.
+4. **`split`** (optional): How to split along named dimensions.
 
 See the [Custom Linops](../howto/custom_linops.md) guide for the full details and conventions.
 

--- a/docs/explanations/multi_gpu.md
+++ b/docs/explanations/multi_gpu.md
@@ -8,13 +8,11 @@ We assume CUDA devices with peer-to-peer memory access.
 
 At its core, multi-GPU distribution is built on the ability to **split** a linop into smaller sub-linops that each operate on a slice of the data.
 
-### `split_forward`
+### `split`
 
-Every `NamedLinop` can implement `split_forward(ibatch, obatch)`, where `ibatch` and `obatch` are lists of slices corresponding to the input and output dimensions. The method returns a new linop that operates only on the specified slice.
+Every `NamedLinop` can implement `split(linop, tile)`, where `tile` is a dictionary mapping dimension names to slices. The method returns a new linop that operates only on the specified slice.
 
 For example, a `Diagonal` linop with shape `(Nx, Ny) -> (Nx, Ny)` and a weight tensor of shape `(256, 256)` can be split along `Nx` into two sub-linops, each with a weight of shape `(128, 256)`.
-
-The static `split(linop, tile)` method provides a higher-level interface that accepts a dictionary mapping dimension names to slices:
 
 ```python
 from torchlinops.nameddim import NamedDimension as ND
@@ -45,9 +43,7 @@ linops, ibatches, obatches = split_linop(A, {"Nx": 128, "Ny": 64})
 
 When splitting a `Chain` (a composition of linops), each constituent linop is split independently according to the slices over its own dimensions. This means that a chain $C \circ B \circ A$ is split into tiles where each tile is a chain of the corresponding sub-linops.
 
-The `Chain.split_forward()` method receives lists of slices per constituent linop:
-- `ibatches`: list of lists, one per linop in the chain
-- `obatches`: list of lists, one per linop in the chain
+The `Chain.split()` method distributes the tile dictionary to each constituent linop based on dimension names.
 
 ## BatchSpec
 

--- a/docs/explanations/named_abstractions.md
+++ b/docs/explanations/named_abstractions.md
@@ -259,7 +259,7 @@ Note that `Chain` stores linops in **execution order** (inner-to-outer), so `A @
 
 ### Splitting
 
-Every linop can implement `split_forward(ibatch, obatch)` to support decomposition into sub-linops along named dimensions. The default `split()` static method translates a tile dictionary (mapping dim names to slices) into the `ibatch`/`obatch` format and delegates to `split_forward`. See [Multi-GPU Splitting](multi_gpu.md) for how this is used to distribute computation.
+Every linop can implement `split(linop, tile)` to support decomposition into sub-linops along named dimensions. The `tile` argument is a dictionary mapping dimension names to slices. See [Multi-GPU Splitting](multi_gpu.md) for how this is used to distribute computation.
 
 ### Size reporting
 

--- a/docs/explanations/why_this_package.md
+++ b/docs/explanations/why_this_package.md
@@ -85,4 +85,4 @@ A_distributed = create_batched_linop(A, spec)
 # A_distributed behaves like A but runs across two GPUs
 ```
 
-The splitting, device transfer, and reassembly logic is handled by the library. Each operator only needs to implement `split_forward` to describe how it decomposes along its dimensions. See [Multi-GPU Splitting](multi_gpu.md) for the full details.
+The splitting, device transfer, and reassembly logic is handled by the library. Each operator only needs to implement `split` to describe how it decomposes along its dimensions. See [Multi-GPU Splitting](multi_gpu.md) for the full details.

--- a/docs/howto/custom_linops.md
+++ b/docs/howto/custom_linops.md
@@ -84,16 +84,20 @@ def normal_fn(x: Tensor, /, weight: Tensor) -> Tensor:
 
 The first positional argument is always the input tensor `x`. Additional arguments are operator-specific data (weights, parameters, etc.) passed from `forward()`.
 
-### 3. Use `type(self)` in `split_forward()`
+### 3. Use `type(linop)` in `split()`
 
-If you override `split_forward()` for multi-GPU splitting, construct new instances using `type(self)(...)` instead of `copy.deepcopy(self)`. This avoids unnecessary tensor copies and ensures proper parameter isolation:
+If you override `split()` for multi-GPU splitting, construct new instances using `type(linop)(...)` instead of `copy.deepcopy(linop)`. This avoids unnecessary tensor copies and ensures proper parameter isolation:
 
 ```python
-def split_forward(self, ibatch, obatch):
+@staticmethod
+def split(linop, tile):
+    # Extract slices for your dimensions
+    ibatch = tuple(tile.get(dim, slice(None)) for dim in linop.ishape)
+    obatch = tuple(tile.get(dim, slice(None)) for dim in linop.oshape)
     # Slice your data for this batch
-    sub_weight = self.weight[obatch, ibatch]
+    sub_weight = linop.weight[obatch, ibatch]
     # Create a new instance (not a copy)
-    return type(self)(sub_weight, ishape=..., oshape=...)
+    return type(linop)(sub_weight, ishape=..., oshape=...)
 ```
 
 See [Copying Linops](../explanations/copying_linops.md) and [Multi-GPU Splitting](../explanations/multi_gpu.md) for more details on why this matters.

--- a/docs/reference/linops/namedlinop.md
+++ b/docs/reference/linops/namedlinop.md
@@ -9,15 +9,14 @@
             - fn
             - adj_fn
             - normal_fn
-            - split_forward
+            - split
+            - adj_split
             - size
             - dims
             - H
             - adjoint
             - N
             - normal
-            - split
-            - adj_split
             - flatten
             - compose
             - apply

--- a/src/torchlinops/linops/add.py
+++ b/src/torchlinops/linops/add.py
@@ -72,9 +72,10 @@ class Add(Threadable, NamedLinop):
             return add.threaded_apply_sum_reduce([x] * len(adj_linops), add.num_workers)
         return sum(linop.H(x) for linop in add.linops)
 
-    def split_forward(self, ibatch, obatch):
-        split = copy(self)
-        linops = [linop.split_forward(ibatch, obatch) for linop in self.linops]
+    @staticmethod
+    def split(add, tile):
+        split = copy(add)
+        linops = [type(linop).split(linop, tile) for linop in add.linops]
         split.linops = nn.ModuleList(linops)
         return split
 

--- a/src/torchlinops/linops/array_to_blocks.py
+++ b/src/torchlinops/linops/array_to_blocks.py
@@ -87,8 +87,9 @@ class ArrayToBlocks(NamedLinop):
     def normal_fn(arraytoblocks, x, /):
         return arraytoblocks.adj_fn(arraytoblocks, arraytoblocks.fn(arraytoblocks, x))
 
-    def split_forward(self, ibatch, obatch):
-        return copy(self)
+    @staticmethod
+    def split(linop, tile):
+        return copy(linop)
 
     def adjoint(self):
         return BlocksToArray(
@@ -181,8 +182,9 @@ class BlocksToArray(NamedLinop):
             blockstoarray.mask,
         )
 
-    def split_forward(self, ibatch, obatch):
-        return copy(self)
+    @staticmethod
+    def split(linop, tile):
+        return copy(linop)
 
     def adjoint(self):
         return ArrayToBlocks(

--- a/src/torchlinops/linops/breakpt.py
+++ b/src/torchlinops/linops/breakpt.py
@@ -26,5 +26,6 @@ class BreakpointLinop(NamedLinop):
         breakpoint()
         return x
 
-    def split_forward(self, ibatch, obatch):
-        return self
+    @staticmethod
+    def split(linop, tile):
+        return linop

--- a/src/torchlinops/linops/chain.py
+++ b/src/torchlinops/linops/chain.py
@@ -96,29 +96,25 @@ class Chain(NamedLinop):
     #     # If the normal hasn't been explicitly formed with`.N`, do things the naive way
     #     return chain.adj_fn(chain, chain.fn(chain, x))
 
-    def split_forward(self, ibatches, obatches):
-        """Split each constituent linop according to per-linop batch slices.
+    @staticmethod
+    def split(chain, tile: Mapping[ND | str, slice]):
+        """Split a chain linop into sub-linops.
+
+        Distributes the tile to each constituent linop based on dimension names.
 
         Parameters
         ----------
-        ibatches : list[list[slice]]
-            Per-linop input slices. Each element is a list of slices corresponding
-            to the input dimensions of one linop in the chain.
-        obatches : list[list[slice]]
-            Per-linop output slices. Each element is a list of slices corresponding
-            to the output dimensions of one linop in the chain.
-
-        Returns
-        -------
-        Chain
-            A new chain of the split sub-linops.
+        chain : Chain
+            The chain linop to split.
+        tile : Mapping[ND | str, slice]
+            Dictionary specifying how to slice the linop dimensions
         """
-        linops = [
-            linop.split_forward(ibatch, obatch)
-            for linop, ibatch, obatch in zip(self.linops, ibatches, obatches)
-        ]
-        split = copy(self)
-        split.linops = nn.ModuleList(linops)
+        split_linops = []
+        for linop in chain.linops:
+            sub_tile = {dim: tile.get(dim, slice(None)) for dim in linop.dims}
+            split_linops.append(type(linop).split(linop, sub_tile))
+        split = copy(chain)
+        split.linops = nn.ModuleList(split_linops)
         return split
 
     def size(self, dim):
@@ -166,48 +162,6 @@ class Chain(NamedLinop):
         for linop in reversed(self.linops):
             inner = linop.normal(inner)
         return inner
-
-    @staticmethod
-    def split(chain, tile: Mapping[ND | str, slice]):
-        """Split a linop into sub-linops.
-
-        Parameters
-        ----------
-        chain : Chain
-            The chain linop to split.
-        tile : Mapping[ND | str, slice]
-            Dictionary specifying how to slice the linop dimensions
-        """
-        ibatches = [
-            [tile.get(dim, slice(None)) for dim in linop.ishape]
-            for linop in chain.linops
-        ]
-        obatches = [
-            [tile.get(dim, slice(None)) for dim in linop.oshape]
-            for linop in chain.linops
-        ]
-        return chain.split_forward(ibatches, obatches)
-
-    @staticmethod
-    def adj_split(chain, tile: Mapping[ND | str, slice]):
-        """Split an adjoint linop into sub-linops.
-
-        Parameters
-        ----------
-        chain : Chain
-            The chain linop to split.
-        tile : Mapping[ND | str, slice]
-            Dictionary specifying how to slice the linop dimensions
-        """
-        ibatches = [
-            [tile.get(dim, slice(None)) for dim in linop.ishape]
-            for linop in chain.linops
-        ]
-        obatches = [
-            [tile.get(dim, slice(None)) for dim in linop.oshape]
-            for linop in chain.linops
-        ]
-        return chain.H.split_forward(obatches, ibatches).H
 
     @property
     def shape(self):

--- a/src/torchlinops/linops/concat.py
+++ b/src/torchlinops/linops/concat.py
@@ -179,30 +179,33 @@ class Concat(Threadable, NamedLinop):
                 if linop.size(dim) is not None:
                     return linop.size(dim)
 
-    def split_forward(self, ibatch, obatch):
+    @staticmethod
+    def split(concat, tile):
         """Split concat linop, making a new concat linop if necessary"""
-        ibatches = self.subslice(ibatch, self.idim_idx, self.islices, len(self.linops))
-        obatches = self.subslice(obatch, self.odim_idx, self.oslices, len(self.linops))
+        ibatch = list(tile.get(dim, slice(None)) for dim in concat.ishape)
+        obatch = list(tile.get(dim, slice(None)) for dim in concat.oshape)
+        ibatches = concat.subslice(ibatch, concat.idim_idx, concat.islices, len(concat.linops))
+        obatches = concat.subslice(obatch, concat.odim_idx, concat.oslices, len(concat.linops))
 
         output_linop_idxs = ibatches.keys() & obatches.keys()
         output_linop_idxs = sorted(list(output_linop_idxs))
         if len(output_linop_idxs) == 0:
             # No linops satisfy this slice (diagonal stacking)
-            return Zero(self.ishape, self.oshape)
+            return Zero(concat.ishape, concat.oshape)
         elif len(output_linop_idxs) == 1:
             # Singleton linop
             linop_idx = output_linop_idxs.pop()
-            linop = self.linops[linop_idx]
-            ibatch, obatch = ibatches[linop_idx], obatches[linop_idx]
-            return linop.split_forward(ibatch, obatch)
+            linop = concat.linops[linop_idx]
+            sub_tile = {dim: tile.get(dim, slice(None)) for dim in linop.dims}
+            return type(linop).split(linop, sub_tile)
         else:
             output_linop_idxs = sorted(list(output_linop_idxs))
             output_linops = []
             for i in output_linop_idxs:
-                linop = self.linops[i]
-                ibatch, obatch = ibatches[i], obatches[i]
-                output_linops.append(linop.split_forward(ibatch, obatch))
-            return self.spinoff(output_linops, idim=self.idim, odim=self.odim)
+                linop = concat.linops[i]
+                sub_tile = {dim: tile.get(dim, slice(None)) for dim in linop.dims}
+                output_linops.append(type(linop).split(linop, sub_tile))
+            return concat.spinoff(output_linops, idim=concat.idim, odim=concat.odim)
 
     @staticmethod
     def subslice(batch: list[slice], dim_idx: Optional[int], slices, num_linops):

--- a/src/torchlinops/linops/dense.py
+++ b/src/torchlinops/linops/dense.py
@@ -234,10 +234,13 @@ class Dense(NamedLinop):
         normal._shape_updates = _shape_updates
         return normal
 
-    def split_forward(self, ibatch, obatch):
-        weight = self.split_weight(ibatch, obatch, self.weight)
-        out = copy(self)
-        out.weight = nn.Parameter(weight, requires_grad=self.weight.requires_grad)
+    @staticmethod
+    def split(dense, tile):
+        ibatch = tuple(tile.get(dim, slice(None)) for dim in dense.ishape)
+        obatch = tuple(tile.get(dim, slice(None)) for dim in dense.oshape)
+        weight = dense.split_weight(ibatch, obatch, dense.weight)
+        out = copy(dense)
+        out.weight = nn.Parameter(weight, requires_grad=dense.weight.requires_grad)
         return out
 
     def split_weight(self, ibatch, obatch, /, weight):

--- a/src/torchlinops/linops/device.py
+++ b/src/torchlinops/linops/device.py
@@ -233,9 +233,10 @@ class ToDevice(NamedLinop):
             return Identity()
         return super().normal(inner)
 
-    def split_forward(self, ibatch, obatch):
+    @staticmethod
+    def split(linop, tile):
         """Return a new instance"""
-        return copy(self)
+        return copy(linop)
 
     def __repr__(self):
         """Helps prevent recursion error caused by .H and .N"""

--- a/src/torchlinops/linops/diagonal.py
+++ b/src/torchlinops/linops/diagonal.py
@@ -154,10 +154,13 @@ class Diagonal(NamedLinop):
             return normal
         return super().normal(inner)
 
-    def split_forward(self, ibatch, obatch):
-        weight = self.split_weight(ibatch, obatch, self.weight)
-        split = copy(self)
-        split.weight = nn.Parameter(weight, requires_grad=self.weight.requires_grad)
+    @staticmethod
+    def split(diagonal, tile):
+        ibatch = tuple(tile.get(dim, slice(None)) for dim in diagonal.ishape)
+        obatch = tuple(tile.get(dim, slice(None)) for dim in diagonal.oshape)
+        weight = diagonal.split_weight(ibatch, obatch, diagonal.weight)
+        split = copy(diagonal)
+        split.weight = nn.Parameter(weight, requires_grad=diagonal.weight.requires_grad)
         return split
 
     def split_weight(self, ibatch, obatch, /, weight):

--- a/src/torchlinops/linops/einops.py
+++ b/src/torchlinops/linops/einops.py
@@ -69,23 +69,26 @@ class Rearrange(NamedLinop):
         axes_lengths = {str(k): v for k, v in linop.axes_lengths.items()}
         return rearrange(x, f"{linop.opattern} -> {linop.ipattern}", **axes_lengths)
 
-    def split_forward(self, ibatch, obatch):
+    @staticmethod
+    def split(rearrange, tile):
         """TODO: Add compound shapes so splitting through rearrange can work."""
         warn(
-            f"Splitting Rearrange linop with shape {self._shape} - splitting a rearrange may behave unusually."
+            f"Splitting Rearrange linop with shape {rearrange._shape} - splitting a rearrange may behave unusually."
         )
-        new_axes_lengths = deepcopy(self.axes_lengths)
-        for dim, slc in zip(self.ishape, ibatch):
-            if dim in self.axes_lengths:
-                n = self.axes_lengths[dim]
+        ibatch = tuple(tile.get(dim, slice(None)) for dim in rearrange.ishape)
+        obatch = tuple(tile.get(dim, slice(None)) for dim in rearrange.oshape)
+        new_axes_lengths = deepcopy(rearrange.axes_lengths)
+        for dim, slc in zip(rearrange.ishape, ibatch):
+            if dim in rearrange.axes_lengths:
+                n = rearrange.axes_lengths[dim]
                 new_axes_lengths[dim] = slicelen(n, slc)
-        for dim, slc in zip(self.oshape, obatch):
-            if dim in self.axes_lengths:
-                n = self.axes_lengths[dim]
+        for dim, slc in zip(rearrange.oshape, obatch):
+            if dim in rearrange.axes_lengths:
+                n = rearrange.axes_lengths[dim]
                 new_axes_lengths[dim] = slicelen(n, slc)
 
-        out = type(self)(
-            self.ipattern, self.opattern, self.ishape, self.oshape, new_axes_lengths
+        out = type(rearrange)(
+            rearrange.ipattern, rearrange.opattern, rearrange.ishape, rearrange.oshape, new_axes_lengths
         )
         return out
 
@@ -130,8 +133,9 @@ class SumReduce(NamedLinop):
         x = repeat(x, f"{sumreduce.opattern} -> {sumreduce.adj_ipattern}")
         return x
 
-    def split_forward(self, ibatch, obatch):
-        return self
+    @staticmethod
+    def split(linop, tile):
+        return linop
 
     def size(self, dim: str):
         """Reducing does not determine any dimensions"""
@@ -256,14 +260,16 @@ class Repeat(NamedLinop):
         x = reduce(x, f"{linop.opattern} -> {linop.ipattern}", "sum")
         return x
 
-    def split_forward(self, ibatch, obatch):
+    @staticmethod
+    def split(repeat, tile):
         """Repeat fewer times, depending on the size of obatch"""
-        new_axes_lengths = deepcopy(self.axes_lengths)
-        for dim, slc in zip(self.oshape, obatch):
-            if dim in self.axes_lengths and dim not in self.broadcast_dims:
-                new_axes_lengths[dim] = slicelen(self.size(dim), slc)
-        return type(self)(
-            new_axes_lengths, self.ishape, self.oshape, self.broadcast_dims
+        obatch = tuple(tile.get(dim, slice(None)) for dim in repeat.oshape)
+        new_axes_lengths = deepcopy(repeat.axes_lengths)
+        for dim, slc in zip(repeat.oshape, obatch):
+            if dim in repeat.axes_lengths and dim not in repeat.broadcast_dims:
+                new_axes_lengths[dim] = slicelen(repeat.size(dim), slc)
+        return type(repeat)(
+            new_axes_lengths, repeat.ishape, repeat.oshape, repeat.broadcast_dims
         )
 
     def size(self, dim: str):

--- a/src/torchlinops/linops/fft.py
+++ b/src/torchlinops/linops/fft.py
@@ -103,10 +103,11 @@ class FFT(NamedLinop):
     def normal_fn(linop, x):
         return x
 
-    def split_forward(self, ibatch, obatch):
+    @staticmethod
+    def split(linop, tile):
         """Splitting does nothing."""
         # TODO: raise an error if the FFT is split along an input or output grid dim
-        new = copy(self)
+        new = copy(linop)
         return new
 
     def normal(self, inner=None):

--- a/src/torchlinops/linops/identity.py
+++ b/src/torchlinops/linops/identity.py
@@ -40,10 +40,9 @@ class Identity(NamedLinop):
         # A bit faster
         return x
 
-    def split_forward(self, ibatch, obatch):
-        # TODO: Allow non-diagonal splitting
-        assert ibatch == obatch, "Identity linop must be split identically"
-        return self
+    @staticmethod
+    def split(linop, tile):
+        return linop
 
     def __pow__(self, _: float | Tensor):
         return copy(self)
@@ -70,8 +69,9 @@ class Zero(NamedLinop):
     def normal_fn(self, x, /):
         return zeros_like(x)
 
-    def split_forward(self, ibatch, obatch):
-        return self
+    @staticmethod
+    def split(linop, tile):
+        return linop
 
 
 class ShapeSpec(Identity):

--- a/src/torchlinops/linops/interp.py
+++ b/src/torchlinops/linops/interp.py
@@ -103,17 +103,19 @@ class Interpolate(NamedLinop):
             x, interp.locs, interp.grid_size, **interp.interp_params
         )
 
-    def split_forward(self, ibatch, obatch):
-        return type(self)(
-            self.split_locs(ibatch, obatch, self.locs),
-            self.grid_size,
-            self._shape.batch_shape,
-            self._shape.locs_batch_shape,
-            self._shape.grid_shape,
-            **self.interp_params,
+    @staticmethod
+    def split(interp, tile):
+        obatch = tuple(tile.get(dim, slice(None)) for dim in interp.oshape)
+        return type(interp)(
+            interp.split_locs(obatch, interp.locs),
+            interp.grid_size,
+            interp._shape.batch_shape,
+            interp._shape.locs_batch_shape,
+            interp._shape.grid_shape,
+            **interp.interp_params,
         )
 
-    def split_locs(self, ibatch, obatch, /, locs):
+    def split_locs(self, obatch, /, locs):
         """Can only split on locs dimensions"""
         if self._shape.locs_batch_shape == ELLIPSES:
             return locs

--- a/src/torchlinops/linops/namedlinop.py
+++ b/src/torchlinops/linops/namedlinop.py
@@ -193,28 +193,49 @@ class NamedLinop(nn.Module):
         """
         return linop.adj_fn(linop, linop.fn(linop, x))
 
-    # Override
-    def split_forward(self, ibatch, obatch) -> "NamedLinop":
-        """Split this linop into a sub-linop according to slices over its dimensions.
+    @staticmethod
+    def split(linop, tile: Mapping[ND | str, slice]) -> "NamedLinop":
+        """Split a linop into a sub-linop for a given tile.
 
         Override this in subclasses to define how the linop decomposes when tiled
-        along its named dimensions. For the companion method that handles adjoints,
-        see ``adj_split``.
+        along its named dimensions.
 
         Parameters
         ----------
-        ibatch : tuple[slice, ...]
-            Slices over the input dimensions, one per element of ``ishape``.
-        obatch : tuple[slice, ...]
-            Slices over the output dimensions, one per element of ``oshape``.
+        linop : NamedLinop
+            The linop to split.
+        tile : Mapping[ND | str, slice]
+            Dictionary mapping dimension names to slices.
 
         Returns
         -------
         NamedLinop
             A new linop that operates on the specified slice of the data.
         """
+        return type(linop)(linop._shape)
 
-        return type(self)(self._shape)
+    @final
+    @staticmethod
+    def adj_split(linop, tile: Mapping[ND | str, slice]) -> "NamedLinop":
+        """Split the adjoint of this linop for a given tile.
+
+        Constructs the adjoint, splits it according to *tile*, and returns the
+        adjoint of the split.
+
+        Parameters
+        ----------
+        linop : NamedLinop
+            The linop whose adjoint should be split.
+        tile : Mapping[ND | str, slice]
+            Dictionary mapping dimension names to slices.
+
+        Returns
+        -------
+        NamedLinop
+            The split adjoint sub-linop.
+        """
+        adj = linop.adjoint()
+        return type(adj).split(adj, tile).adjoint()
 
     # Override
     def size(self, dim: str) -> int | None:
@@ -375,55 +396,6 @@ class NamedLinop(nn.Module):
         normal = post @ inner @ pre
         normal._shape_updates = getattr(inner, "_shape_updates", {})
         return normal
-
-    @final
-    @staticmethod
-    def split(linop, tile: Mapping[ND | str, slice]) -> "NamedLinop":
-        """Split a linop into a sub-linop for a given tile.
-
-        Translates a tile dictionary into per-dimension slices and delegates
-        to ``split_forward``.
-
-        Parameters
-        ----------
-        linop : NamedLinop
-            The linop to split.
-        tile : Mapping[ND | str, slice]
-            Dictionary mapping dimension names to slices.
-
-        Returns
-        -------
-        NamedLinop
-            The sub-linop operating on the specified tile.
-        """
-        ibatch = [tile.get(dim, slice(None)) for dim in linop.ishape]
-        obatch = [tile.get(dim, slice(None)) for dim in linop.oshape]
-        return linop.split_forward(ibatch, obatch)
-
-    @final
-    @staticmethod
-    def adj_split(linop, tile: Mapping[ND | str, slice]) -> "NamedLinop":
-        """Split the adjoint of this linop for a given tile.
-
-        Constructs the adjoint, splits it according to *tile*, and returns the
-        adjoint of the split.
-
-        Parameters
-        ----------
-        linop : NamedLinop
-            The linop whose adjoint should be split.
-        tile : Mapping[ND | str, slice]
-            Dictionary mapping dimension names to slices.
-
-        Returns
-        -------
-        NamedLinop
-            The split adjoint sub-linop.
-        """
-        ibatch = [tile.get(dim, slice(None)) for dim in linop.ishape]
-        obatch = [tile.get(dim, slice(None)) for dim in linop.oshape]
-        splitH = linop.adjoint().split_forward(obatch, ibatch).adjoint()
-        return splitH
 
     def flatten(self) -> list["NamedLinop"]:
         """Get a flattened list of constituent linops for composition."""

--- a/src/torchlinops/linops/nufft.py
+++ b/src/torchlinops/linops/nufft.py
@@ -362,21 +362,19 @@ class NUFFT(Chain):
         apod = torch.prod(apod, dim=-1)
         return apod
 
-    def split_forward(self, ibatch, obatch):
-        ibatch_lookup = {d: slc for d, slc in zip(self.ishape, ibatch)}
-        obatch_lookup = {d: slc for d, slc in zip(self.oshape, obatch)}
+    @staticmethod
+    def split(nufft, tile):
         split_linops = []
-        for linop in self.linops:
-            sub_ibatch = [ibatch_lookup.get(dim, slice(None)) for dim in linop.ishape]
-            sub_obatch = [obatch_lookup.get(dim, slice(None)) for dim in linop.oshape]
-            split_linops.append(linop.split_forward(sub_ibatch, sub_obatch))
-        out = copy(self)
+        for linop in nufft.linops:
+            sub_tile = {dim: tile.get(dim, slice(None)) for dim in linop.dims}
+            split_linops.append(type(linop).split(linop, sub_tile))
+        out = copy(nufft)
         out.linops = nn.ModuleList(split_linops)
         return out
 
     def flatten(self):
         """Don't combine constituent linops into a chain with other linops
-        Informs how split_forward should behave
+        Informs how split should behave
         """
         return [self]
 

--- a/src/torchlinops/linops/pad_last.py
+++ b/src/torchlinops/linops/pad_last.py
@@ -111,13 +111,16 @@ class Pad(NamedLinop):
         adj.in_im_size, adj.out_im_size = self.out_im_size, self.in_im_size
         return adj
 
-    def split_forward(self, ibatch, obatch):
-        for islc, oslc in zip(ibatch[-self.D :], obatch[-self.D :]):
+    @staticmethod
+    def split(pad, tile):
+        ibatch = tuple(tile.get(dim, slice(None)) for dim in pad.ishape)
+        obatch = tuple(tile.get(dim, slice(None)) for dim in pad.oshape)
+        for islc, oslc in zip(ibatch[-pad.D :], obatch[-pad.D :]):
             if islc != slice(None) or oslc != slice(None):
                 raise ValueError(
-                    f"{type(self).__name__} cannot be split along image dim"
+                    f"{type(pad).__name__} cannot be split along image dim"
                 )
-        return self
+        return pad
 
     def size(self, dim: str):
         if dim in self.ishape[-self.D :]:

--- a/src/torchlinops/linops/sampling.py
+++ b/src/torchlinops/linops/sampling.py
@@ -100,16 +100,19 @@ class Sampling(NamedLinop):
     def adj_fn(sampling, x, /):
         return F.index_adjoint(x, tuple(sampling.idx), sampling.input_size)
 
-    def split_forward(self, ibatch, obatch):
-        if self._shape.output_shape == ELLIPSES:
+    @staticmethod
+    def split(sampling, tile):
+        ibatch = tuple(tile.get(dim, slice(None)) for dim in sampling.ishape)
+        obatch = tuple(tile.get(dim, slice(None)) for dim in sampling.oshape)
+        if sampling._shape.output_shape == ELLIPSES:
             # Cannot split if idx batch shape is not split
-            return self
-        return type(self)(
-            self.split_idx(ibatch, obatch, self.idx),
-            self.input_size,
-            self._shape.output_shape,
-            self._shape.input_shape,
-            self._shape.batch_shape,
+            return sampling
+        return type(sampling)(
+            sampling.split_idx(ibatch, obatch, sampling.idx),
+            sampling.input_size,
+            sampling._shape.output_shape,
+            sampling._shape.input_shape,
+            sampling._shape.batch_shape,
         )
 
     def split_idx(self, ibatch, obatch, idx):

--- a/src/torchlinops/linops/scalar.py
+++ b/src/torchlinops/linops/scalar.py
@@ -1,3 +1,4 @@
+from copy import copy
 from typing import Optional
 
 import torch
@@ -31,9 +32,11 @@ class Scalar(Diagonal):
         ioshape = default_to(("...",), ioshape)
         super().__init__(weight, ioshape=ioshape)
 
-    def split_weight(self, ibatch, obatch, /, weight):
-        assert ibatch == obatch, "Scalar linop must be split identically"
-        return weight
+    @staticmethod
+    def split(linop, tile):
+        # Scalar applies to all tiles - no slicing needed
+        split = copy(linop)
+        return split
 
     def size(self, dim: str):
         return None

--- a/src/torchlinops/linops/stack.py
+++ b/src/torchlinops/linops/stack.py
@@ -189,37 +189,29 @@ class Stack(Threadable, NamedLinop):
             # https://github.com/pytorch/pytorch/issues/80821
             return self.linops[0].size(dim)  # type: ignore
 
-    def split_forward(self, ibatch, obatch):
+    @staticmethod
+    def split(stack, tile):
         """Split stack linop"""
-        linop_idxs = set(range(len(self.linops)))
-        for i, slc in enumerate(ibatch):
-            if i == self.idim_idx:
-                linop_idxs &= set(slice2range(slc, len(self.linops)))
-        for i, slc in enumerate(obatch):
-            if i == self.odim_idx:
-                linop_idxs &= set(slice2range(slc, len(self.linops)))
+        ibatch = tuple(tile.get(dim, slice(None)) for dim in stack.ishape)
+        obatch = tuple(tile.get(dim, slice(None)) for dim in stack.oshape)
+        linop_idxs = set(range(len(stack.linops)))
+        if stack.idim_idx is not None:
+            linop_idxs &= set(slice2range(ibatch[stack.idim_idx], len(stack.linops)))
+        if stack.odim_idx is not None:
+            linop_idxs &= set(slice2range(obatch[stack.odim_idx], len(stack.linops)))
 
         if len(linop_idxs) == 0:
             # No linops satisfy this slice (diagonal stacking)
-            return Zero(self.ishape, self.oshape)
+            return Zero(stack.ishape, stack.oshape)
         linop_idxs = sorted(list(linop_idxs))
         output_linops = []
-        # Remove stack dims from slice batch
-        if self.idim_idx is not None:
-            ibatch = ibatch.copy()
-            ibatch.pop(self.idim_idx)
-        if self.odim_idx is not None:
-            obatch = obatch.copy()
-            obatch.pop(self.odim_idx)
 
         # Slice each sub-linop
         for i in linop_idxs:
-            linop = self.linops[i]
-            islices = {dim: slc for dim, slc in zip(linop.ishape, ibatch)}
-            oslices = {dim: slc for dim, slc in zip(linop.oshape, obatch)}
-            slices = strict_update(islices, oslices)
-            output_linops.append(linop.split(linop, slices))
-        return self.spinoff(output_linops)
+            linop = stack.linops[i]
+            sub_tile = {dim: tile.get(dim, slice(None)) for dim in linop.dims}
+            output_linops.append(type(linop).split(linop, sub_tile))
+        return stack.spinoff(output_linops)
 
     def split_data(self, ibatch, obatch, data_list):
         """Split stack linop, making a new stack linop if necessary

--- a/src/torchlinops/linops/trunc_pad.py
+++ b/src/torchlinops/linops/trunc_pad.py
@@ -78,11 +78,14 @@ class Truncate(NamedLinop):
         x[truncate.end_slc] = 0.0
         return x
 
-    def split_forward(self, ibatch, obatch):
-        if ibatch[self.dim] != slice(None) or obatch[self.dim] != slice(None):
+    @staticmethod
+    def split(truncate, tile):
+        ibatch = tuple(tile.get(dim, slice(None)) for dim in truncate.ishape)
+        obatch = tuple(tile.get(dim, slice(None)) for dim in truncate.oshape)
+        if ibatch[truncate.dim] != slice(None) or obatch[truncate.dim] != slice(None):
             raise ValueError("Cannot slice a Truncate linop along truncation dimension")
-        return type(self)(
-            self.dim, self.from_length, self.to_length, self.ishape, self.oshape
+        return type(truncate)(
+            truncate.dim, truncate.from_length, truncate.to_length, truncate.ishape, truncate.oshape
         )
 
     def adjoint(self):
@@ -168,9 +171,12 @@ class PadDim(NamedLinop):
         x = x.clone()
         return x
 
-    def split_forward(self, ibatch, obatch):
-        if ibatch[self.dim] != slice(None) or obatch[self.dim] != slice(None):
+    @staticmethod
+    def split(padend, tile):
+        ibatch = tuple(tile.get(dim, slice(None)) for dim in padend.ishape)
+        obatch = tuple(tile.get(dim, slice(None)) for dim in padend.oshape)
+        if ibatch[padend.dim] != slice(None) or obatch[padend.dim] != slice(None):
             raise ValueError("Cannot slice a PadEnd linop along truncation dimension")
-        return type(self)(
-            self.dim, self.from_length, self.to_length, self.ishape, self.oshape
+        return type(padend)(
+            padend.dim, padend.from_length, padend.to_length, padend.ishape, padend.oshape
         )

--- a/src/torchlinops/tests/test_device_coverage.py
+++ b/src/torchlinops/tests/test_device_coverage.py
@@ -34,7 +34,7 @@ def test_todevice_normal():
 
 def test_todevice_split():
     td = ToDevice(torch.device("cpu"), torch.device("cpu"))
-    s = td.split_forward(None, None)
+    s = type(td).split(td, {})
     assert s is not None
 
 

--- a/src/torchlinops/tests/test_diagonal.py
+++ b/src/torchlinops/tests/test_diagonal.py
@@ -95,12 +95,8 @@ def test_diagonal_split_with_broadcast_dims():
     # broadcast_dims=("M",) means M is not indexed in the weight
     A = Diagonal(weight, ioshape=("M", "N"), broadcast_dims=["M"])
     # Split along the non-broadcast dim N
-    ibatch = [slice(None), slice(0, 3)]
-    obatch = [slice(None), slice(0, 3)]
-    A_split = A.split_forward(ibatch, obatch)
+    A_split = type(A).split(A, {"M": slice(None), "N": slice(0, 3)})
     assert A_split.weight.shape == (3,)
     # Split along the broadcast dim M — weight should stay the same
-    ibatch_m = [slice(0, 4), slice(None)]
-    obatch_m = [slice(0, 4), slice(None)]
-    A_split_m = A.split_forward(ibatch_m, obatch_m)
+    A_split_m = type(A).split(A, {"M": slice(0, 4), "N": slice(None)})
     assert torch.allclose(A_split_m.weight, weight)

--- a/src/torchlinops/tests/test_einops.py
+++ b/src/torchlinops/tests/test_einops.py
@@ -41,9 +41,9 @@ class TestRearrange(BaseNamedLinopTests):
     def test_split(self, linop_input_output):
         A, x, y = linop_input_output
         with pytest.warns(UserWarning, match="splitting"):
-            A.split_forward(
-                [slice(None), slice(None)],
-                [slice(None), slice(None), slice(None)],
+            type(A).split(
+                A,
+                {"Ab": slice(None), "C": slice(None)},
             )
 
 
@@ -80,13 +80,13 @@ class TestRepeat(BaseNamedLinopTests):
         s = A.size("C")
         assert s == 3
 
-    def test_split_forward_no_mutation(self, linop_input_output):
-        """split_forward must not mutate the original axes_lengths."""
+    def test_split_no_mutation(self, linop_input_output):
+        """split must not mutate the original axes_lengths."""
         A, x, y = linop_input_output
         original_c = A.axes_lengths["C"]
-        A_split = A.split_forward(
-            [slice(None), slice(None)],
-            [slice(None), slice(None), slice(0, 2)],
+        A_split = type(A).split(
+            A,
+            {"A": slice(None), "B": slice(None), "C": slice(0, 2)},
         )
         assert A.axes_lengths["C"] == original_c
         assert A_split.axes_lengths["C"] == 2
@@ -120,7 +120,7 @@ def test_repeat_same_length_raises():
 
 
 def test_rearrange_split_emits_warning():
-    """split_forward on a Rearrange should emit a UserWarning."""
+    """split on a Rearrange should emit a UserWarning."""
     A = Rearrange(
         "(A B) C",
         "A B C",
@@ -129,7 +129,7 @@ def test_rearrange_split_emits_warning():
         axes_lengths={"A": 2, "B": 3},
     )
     with pytest.warns(UserWarning, match="splitting"):
-        A.split_forward(
-            [slice(None), slice(None)],
-            [slice(None), slice(None), slice(None)],
+        type(A).split(
+            A,
+            {"Ab": slice(None), "C": slice(None)},
         )

--- a/src/torchlinops/tests/test_fft.py
+++ b/src/torchlinops/tests/test_fft.py
@@ -48,14 +48,11 @@ class TestFFTNotCentered(BaseNamedLinopTests):
         return F, x, y
 
 
-def test_fft_split_forward():
-    """split_forward should return an FFT with identical behaviour."""
+def test_fft_split():
+    """split should return an FFT with identical behaviour."""
     F = FFT(ndim=2, centered=True, norm="ortho")
     x = torch.randn(8, 10, dtype=torch.complex64)
-    F_split = F.split_forward(
-        [slice(None), slice(None)],
-        [slice(None), slice(None)],
-    )
+    F_split = type(F).split(F, {})
     assert isinstance(F_split, FFT)
     assert torch.allclose(F(x), F_split(x))
 

--- a/tutorials/custom_linop.py
+++ b/tutorials/custom_linop.py
@@ -25,7 +25,7 @@ def _(mo):
        adjoint operation $y = A^H x$.
 
     Optionally you can also override `normal_fn` (for an efficient $A^H A$),
-    `split_forward` (for multi-GPU tiling), and `size` (to report dimension
+    `split` (for multi-GPU tiling), and `size` (to report dimension
     sizes).
     """)
     return


### PR DESCRIPTION
## Summary

- **Remove `split_forward`** from `NamedLinop` and all subclasses. The split API now uses tile dictionaries directly.
- **`split(linop, tile)`** is now the single override point (was previously a `@final` wrapper that delegated to `split_forward`).
- **`adj_split`** now uses `type(adj).split(adj, tile).adjoint()` to bypass the method swap on adjoints and avoid infinite recursion.
- **Collapse Chain's 3 split overrides** (`split_forward`, `split`, `adj_split`) into a single `split` override that distributes the tile dict to constituent linops by dimension name.
- Update all composite linops (`Add`, `Concat`, `Stack`, `NUFFT`) and all non-composite linops (15 classes across 12 files).
- Update tests and documentation.
- Closes #111 

## Testing

All 603 tests pass (16 skipped for GPU requirements, 2 expected failures unrelated to this change).

## Impact

- **Breaking change** for anyone who overrode `split_forward` on custom linops. They now need to override `split(linop, tile)` instead.
- **Simpler API**: One override point instead of three. Subclasses work with tile dicts directly rather than positional slice lists.